### PR TITLE
Revert "Fix one-line installer temp file path and macOS compatibility"

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -371,12 +371,8 @@ install_codex() {
 		if command -v codex &>/dev/null; then
 			log_warning "Codex CLI is already installed"
 		else
-			if execute "npm install -g @openai/codex"; then
-				log_success "Codex CLI installed"
-			else
-				log_error "Failed to install Codex CLI"
-				return 1
-			fi
+			execute "npm install -g @openai/codex-cli"
+			log_success "Codex CLI installed"
 		fi
 	}
 


### PR DESCRIPTION
Reverts jellydn/my-ai-tools#33
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts changes to Codex CLI installation and macOS-specific backup handling, simplifying commands and temp file paths.
> 
>   - **Behavior**:
>     - Reverts installation command for Codex CLI in `cli.sh` to a simpler form without error handling.
>     - Removes macOS-specific logic for finding old backups in `cleanup_old_backups()` in `lib/common.sh`.
>   - **Temp Files**:
>     - Reverts to using `/tmp` for temporary script files in `download_and_verify_script()` in `lib/common.sh`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jellydn%2Fmy-ai-tools&utm_source=github&utm_medium=referral)<sup> for b36a03905bfa95151220239fe40e88bf51b5be54. You can [customize](https://app.ellipsis.dev/jellydn/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined installation process with simplified error handling
  * Improved temporary file and backup cleanup management during installation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->