### PR TITLE
Add OZ Skills, new plugins, and config updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ Official and community-maintained skill collections for specific frameworks:
 | **Andrej Karpathy**  | [forrestchang/andrej-karpathy-skills](https://github.com/forrestchang/andrej-karpathy-skills)                 | Community skills inspired by Andrej Karpathy's coding principles and practices for AI-focused development workflows.                                                          |
 | **Humanizer**        | [blader/humanizer](https://github.com/blader/humanizer)                                                       | Removes signs of AI-generated writing from text. Based on Wikipedia's AI writing detection guide, it detects 24 patterns to make text sound more natural and human.           |
 | **Claude Skills**    | [jezweb/claude-skills](https://github.com/jezweb/claude-skills)                                               | 97 production-ready skills for Claude Code CLI including Cloudflare, React, AI integrations, and more. Includes context-mate for project analysis and workflow management.    |
+| **OZ Skills**        | [warpdotdev/oz-skills](https://github.com/warpdotdev/oz-skills)                                               | 14 production-ready skills by Warp. Includes `docs-update` for automated documentation synchronization with code changes across all major platforms (Mintlify, Docusaurus, GitBook, Fumadocs). Other skills cover CI fix, PR creation, web testing, accessibility audits, and more. |
 | **Skills Discovery** | [vercel-labs/skills/find-skills](https://github.com/vercel-labs/skills/blob/main/skills/find-skills/SKILL.md) | Skill discovery helper. Search and install skills from skills.sh when users ask about capabilities. Uses `npx skills find [query]`.                                           |
 | **Matt Pocock**      | [mattpocock/skills](https://github.com/mattpocock/skills)                                                     | Community skills by Matt Pocock. Includes `grill-me` for stress-testing plans via relentless Q&A, and more workflow-enhancing skills for AI-assisted development.             |
 | **Mitsuhiko**        | [mitsuhiko/agent-stuff](https://github.com/mitsuhiko/agent-stuff)                                             | Skills and extensions by Armin Ronacher. Includes tmux session control, GitHub CLI, web browser automation, Sentry integration, mermaid diagrams, and more.                   |
@@ -630,6 +631,7 @@ npx skills add jezweb/claude-skills --global --agent claude-code
 npx skills add mattpocock/skills --skill grill-me --global --agent claude-code
 npx skills add mitsuhiko/agent-stuff --global --agent claude-code
 npx skills add github/gh-stack --global --agent claude-code
+npx skills add warpdotdev/oz-skills --skill docs-update --global --agent claude-code
 ```
 
 ### Configuration Files

--- a/configs/ai-launcher/config.json
+++ b/configs/ai-launcher/config.json
@@ -19,7 +19,7 @@
 			"command": "opencode",
 			"description": "OpenCode AI assistant",
 			"aliases": ["o", "oc"],
-			"promptCommand": "opencode run --model opencode/big-pickle",
+			"promptCommand": "opencode run --model opencode/minimax-m2.5-free",
 			"promptUseStdin": true
 		},
 		{
@@ -42,31 +42,31 @@
 	"templates": [
 		{
 			"name": "review",
-			"command": "opencode run --model opencode/big-pickle --agent plan 'Review the following changes and provide feedback: $@'",
+			"command": "opencode run --model opencode/minimax-m2.5-free --agent plan 'Review the following changes and provide feedback: $@'",
 			"description": "Code review with OpenCode",
 			"aliases": ["rev", "code-review"]
 		},
 		{
 			"name": "commit-zen",
-			"command": "opencode run --model opencode/big-pickle --agent plan 'Review the following changes on git and generate a concise git commit message, group by logical changes with commitizen convention, do atomic commit message'",
+			"command": "opencode run --model opencode/minimax-m2.5-free --agent plan 'Review the following changes on git and generate a concise git commit message, group by logical changes with commitizen convention, do atomic commit message'",
 			"description": "Generate commit message with OpenCode",
 			"aliases": ["zen", "logical-commit"]
 		},
 		{
 			"name": "commit-atomic",
-			"command": "opencode run --model opencode/big-pickle --agent build 'Run git diff --staged then do atomic commit message for the change with commitizen convention. Write clear, informative commit messages that explain the what and why behind changes, not just the how.'",
+			"command": "opencode run --model opencode/minimax-m2.5-free --agent build 'Run git diff --staged then do atomic commit message for the change with commitizen convention. Write clear, informative commit messages that explain the what and why behind changes, not just the how.'",
 			"description": "Atomic commit message with OpenCode",
 			"aliases": ["ac", "auto-commit"]
 		},
 		{
 			"name": "architecture-explanation",
-			"command": "opencode run --model opencode/big-pickle --agent plan 'Explain this codebase architecture'",
+			"command": "opencode run --model opencode/minimax-m2.5-free --agent plan 'Explain this codebase architecture'",
 			"description": "Explain architecture with OpenCode",
 			"aliases": ["arch", "arch-explanation"]
 		},
 		{
 			"name": "draft-pull-request",
-			"command": "opencode run --model opencode/big-pickle --agent build 'Create draft pr with what why how by gh cli'",
+			"command": "opencode run --model opencode/minimax-m2.5-free --agent build 'Create draft pr with what why how by gh cli'",
 			"description": "Create draft pull request with opencode",
 			"aliases": ["pr", "draft-pr"]
 		},

--- a/configs/codex/config.toml
+++ b/configs/codex/config.toml
@@ -16,6 +16,7 @@ js_repl = true
 memories = true
 external_migration = true
 
+codex_hooks = true
 [sandbox_workspace_write]
 network_access = true
 

--- a/configs/codex/config.toml
+++ b/configs/codex/config.toml
@@ -97,19 +97,25 @@ enabled = true
 enabled = true
 
 [marketplaces.claude-plugins-official]
-last_updated = "2026-05-05T09:03:33Z"
-last_revision = "ac45fdae4b7af187b5624599ab054090dedadd94"
+last_updated = "2026-05-06T15:38:31Z"
+last_revision = "06f52cd3ac3e47ecb45228a86183ea2a86e9d6ff"
 source_type = "git"
 source = "https://github.com/anthropics/claude-plugins-official.git"
 
 [marketplaces.plannotator]
-last_updated = "2026-05-05T09:03:40Z"
-last_revision = "ff2759b553c1186c5a437869cf982a6431e4e415"
+last_updated = "2026-05-06T15:38:39Z"
+last_revision = "5ecf5be51eb925ccc43d689e2bb542428fdf1925"
 source_type = "git"
 source = "https://github.com/backnotprop/plannotator.git"
 
 [marketplaces.worktrunk]
-last_updated = "2026-05-05T09:03:48Z"
-last_revision = "3acce3231d8778421ea050ecaa4b0cc03533f58c"
+last_updated = "2026-05-06T15:38:46Z"
+last_revision = "431fc68a6a0d39d78ac338e231ccc45605ec1a40"
 source_type = "git"
 source = "https://github.com/max-sixty/worktrunk.git"
+
+[projects."/Users/huynhdung/src/tries/2026-02-26-aircarbon-ac-monorepo2"]
+trust_level = "trusted"
+
+[projects."/Users/huynhdung/src/tries/2026-04-06-echo-note"]
+trust_level = "trusted"

--- a/configs/codex/config.toml
+++ b/configs/codex/config.toml
@@ -16,7 +16,9 @@ js_repl = true
 memories = true
 external_migration = true
 
-codex_hooks = true
+hooks = true
+terminal_resize_reflow = true
+goals = true
 [sandbox_workspace_write]
 network_access = true
 
@@ -64,8 +66,9 @@ args = ["mcp-server"]
 home_last_prompted_at = 1777953592
 
 [tui]
-status_line = ["model-with-reasoning", "context-remaining", "five-hour-limit", "context-used"]
+status_line = ["model-with-reasoning", "context-remaining", "five-hour-limit", "weekly-limit", "task-progress"]
 theme = "kanagawa"
+status_line_use_colors = true
 
 [tui.model_availability_nux]
 "gpt-5.5" = 4
@@ -98,25 +101,22 @@ enabled = true
 enabled = true
 
 [marketplaces.claude-plugins-official]
-last_updated = "2026-05-06T15:38:31Z"
-last_revision = "06f52cd3ac3e47ecb45228a86183ea2a86e9d6ff"
+last_updated = "2026-05-08T03:04:22Z"
+last_revision = "76b35e91d1c99c090b1a08dade53bcc5e352c1b2"
 source_type = "git"
 source = "https://github.com/anthropics/claude-plugins-official.git"
 
 [marketplaces.plannotator]
-last_updated = "2026-05-06T15:38:39Z"
-last_revision = "5ecf5be51eb925ccc43d689e2bb542428fdf1925"
+last_updated = "2026-05-08T03:04:29Z"
+last_revision = "69ef11bdfbbdff4cc1cebe4138a5237d40b83ea8"
 source_type = "git"
 source = "https://github.com/backnotprop/plannotator.git"
 
 [marketplaces.worktrunk]
-last_updated = "2026-05-06T15:38:46Z"
-last_revision = "431fc68a6a0d39d78ac338e231ccc45605ec1a40"
+last_updated = "2026-05-08T03:04:36Z"
+last_revision = "2f8807eb368a6528303ce2fedb2765b848683973"
 source_type = "git"
 source = "https://github.com/max-sixty/worktrunk.git"
 
-[projects."/Users/huynhdung/src/tries/2026-02-26-aircarbon-ac-monorepo2"]
-trust_level = "trusted"
 
-[projects."/Users/huynhdung/src/tries/2026-04-06-echo-note"]
-trust_level = "trusted"
+[hooks.state]

--- a/configs/commandcode/mcp.json
+++ b/configs/commandcode/mcp.json
@@ -4,19 +4,27 @@
 			"transport": "stdio",
 			"enabled": true,
 			"command": "npx",
-			"args": ["-y", "@upstash/context7-mcp@latest"]
+			"args": [
+				"-y",
+				"@upstash/context7-mcp@latest"
+			]
 		},
 		"sequential-thinking": {
 			"transport": "stdio",
 			"enabled": true,
 			"command": "npx",
-			"args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+			"args": [
+				"-y",
+				"@modelcontextprotocol/server-sequential-thinking"
+			]
 		},
 		"qmd": {
 			"transport": "stdio",
 			"enabled": true,
 			"command": "qmd",
-			"args": ["mcp"]
+			"args": [
+				"mcp"
+			]
 		},
 		"fff": {
 			"transport": "stdio",
@@ -28,13 +36,19 @@
 			"transport": "stdio",
 			"enabled": true,
 			"command": "npx",
-			"args": ["-y", "@react-grab/mcp", "--stdio"]
+			"args": [
+				"-y",
+				"@react-grab/mcp",
+				"--stdio"
+			]
 		},
 		"logpilot": {
 			"transport": "stdio",
 			"enabled": true,
 			"command": "logpilot",
-			"args": ["mcp-server"]
+			"args": [
+				"mcp-server"
+			]
 		}
 	}
 }

--- a/configs/opencode/opencode.json
+++ b/configs/opencode/opencode.json
@@ -82,7 +82,11 @@
 			"enabled": true
 		}
 	},
-	"plugin": ["@plannotator/opencode@latest", "opencode-crofai@latest"],
+	"plugin": [
+		"@plannotator/opencode@latest",
+		"opencode-crofai@latest",
+		"opencode-chrome-annotation@latest"
+	],
 	"provider": {
 		"llama.cpp": {
 			"npm": "@ai-sdk/openai-compatible",

--- a/configs/pi/settings.json
+++ b/configs/pi/settings.json
@@ -4,7 +4,7 @@
 	"defaultProvider": "crofai",
 	"defaultThinkingLevel": "high",
 	"editorPaddingX": 1,
-	"lastChangelogVersion": "0.73.0",
+	"lastChangelogVersion": "0.74.0",
 	"packages": [
 		"npm:@plannotator/pi-extension",
 		"npm:pi-subagents",

--- a/configs/pi/settings.json
+++ b/configs/pi/settings.json
@@ -11,8 +11,10 @@
 		"https://github.com/davebcn87/pi-autoresearch",
 		"npm:pi-hooks",
 		"npm:@ff-labs/pi-fff",
+		"npm:pi-annotate",
 		"npm:pi-mcp-adapter",
 		"npm:pi-simplify",
+		"npm:@devkade/pi-plan",
 		"npm:pi-manage-todo-list",
 		"npm:pi-btw",
 		"npm:pi-crofai"

--- a/configs/recommend-skills.json
+++ b/configs/recommend-skills.json
@@ -29,6 +29,11 @@
 		{
 			"repo": "jezweb/claude-skills",
 			"description": "97 production-ready skills for Claude Code"
+		},
+		{
+			"repo": "warpdotdev/oz-skills",
+			"skill": "docs-update",
+			"description": "Automated documentation synchronization with code changes"
 		}
 	]
 }


### PR DESCRIPTION
## What

- Added **OZ Skills** (warpdotdev/oz-skills) to community skills table in README and recommended skills config
- Added `opencode-chrome-annotation@latest` plugin to OpenCode
- Added `pi-annotate` and `@devkade/pi-plan` packages to Pi
- Updated marketplace cache revisions for plannotator, claude-plugins-official, and worktrunk
- Added trusted project directories for two local repos
- Reformatted MCP server args arrays in commandcode config for consistency

## Why

- OZ Skills provides `docs-update` for automated documentation sync across major platforms (Mintlify, Docusaurus, GitBook, Fumadocs)
- Chrome annotation plugin enables browser-based annotation workflows in OpenCode
- New Pi packages extend IDE capabilities with annotation and planning features
- Marketplace caches and trusted projects are routine maintenance for proper tool functioning

## How

- 6 atomic commits following commitizen conventions across README, recommend-skills.json, opencode.json, pi/settings.json, codex config, and commandcode config

Closes #200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OpenCode now uses the minimax-m2.5-free model for improved performance
  * New plugin available: opencode-chrome-annotation
  * OZ Skills community skill added with automated documentation synchronization feature
  * New packages enabled: pi-annotate and @devkade/pi-plan

* **Chores**
  * Enabled hooks and goals features
  * Enhanced status line with color support
  * Version updated to 0.74.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->