### PR TITLE
Add Orca to README tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -2077,6 +2077,14 @@ For React developers:
 - [**React Grab**](https://www.react-grab.com/) - MCP server for extracting and analyzing React components (`@react-grab/mcp`)
 - [**React Scan**](https://react-scan.com/) - Detect performance issues in your React app automatically
 
+### Orca
+
+[**Orca**](https://onOrca.dev) - Next-gen desktop IDE for orchestrating AI coding agents with worktree isolation, multi-agent terminals, and built-in source control. ([GitHub](https://github.com/stablyai/orca))
+
+```bash
+brew install --cask stablyai/orca/orca
+```
+
 </details>
 
 ---

--- a/TESTING.md
+++ b/TESTING.md
@@ -16,6 +16,36 @@ For automated validation, check all scripts with syntax validation:
 bash -n cli.sh generate.sh && echo "All scripts valid"
 ```
 
+## 🧪 Functional Testing with BATS
+
+Functional tests are written using the [BATS (Bash Automated Testing System)](https://github.com/bats-core/bats-core) framework.
+
+### Prerequisites
+
+You must have BATS installed on your system:
+
+```bash
+# On macOS (Homebrew)
+brew install bats-core
+
+# On Ubuntu/Debian
+sudo apt-get install bats
+```
+
+### Running Tests
+
+To run all functional tests:
+
+```bash
+bats tests/
+```
+
+To run a specific test file:
+
+```bash
+bats tests/recommend_skills.bats
+```
+
 Expected exit codes:
 
 - `0` - Syntax is valid

--- a/docs/agent-teams-examples.md
+++ b/docs/agent-teams-examples.md
@@ -264,6 +264,31 @@ Skip style and minor issues - focus on critical security only.
    - Security review
 ```
 
+### Pull Request Review & Fixes
+
+Use the `pr-review` skill to efficiently address review feedback. The skill supports auto-detection from your current branch, specific PR numbers, or full URLs.
+
+```markdown
+# Method 1: Auto-detect from current branch
+
+/pr-review
+
+# Method 2: Use a specific PR number
+
+/pr-review 123
+
+# Method 3: Use a full GitHub PR URL
+
+/pr-review https://github.com/owner/repo/pull/123
+```
+
+**What happens:**
+
+1. The agent fetches all review comments and issue comments for the PR.
+2. It analyzes which comments are still open (unresolved).
+3. It creates a prioritized TODO list based on severity (Critical → High → Medium → Low).
+4. It implements fixes for each comment, runs tests, and commits the changes.
+
 ### Documentation Update
 
 ```markdown

--- a/tests/recommend_skills.bats
+++ b/tests/recommend_skills.bats
@@ -54,41 +54,41 @@ README_FILE="$REPO_ROOT/README.md"
 }
 
 # ---------------------------------------------------------------------------
-# grill-me-with-docs entry (renamed from grill-me)
+# grill-with-docs entry (renamed from grill-me)
 # ---------------------------------------------------------------------------
 
-@test "recommend-skills.json contains grill-me-with-docs skill entry" {
+@test "recommend-skills.json contains grill-with-docs skill entry" {
     if ! command -v jq &>/dev/null; then
         skip "jq not installed"
     fi
-    run jq -e '[.recommended_skills[] | select(.skill == "grill-me-with-docs")] | length > 0' "$RECOMMEND_SKILLS_JSON"
+    run jq -e '[.recommended_skills[] | select(.skill == "grill-with-docs")] | length > 0' "$RECOMMEND_SKILLS_JSON"
     [ "$status" -eq 0 ]
     [ "$output" = "true" ]
 }
 
-@test "grill-me-with-docs entry has correct repo mattpocock/skills" {
+@test "grill-with-docs entry has correct repo mattpocock/skills" {
     if ! command -v jq &>/dev/null; then
         skip "jq not installed"
     fi
-    run jq -r '[.recommended_skills[] | select(.skill == "grill-me-with-docs")][0].repo' "$RECOMMEND_SKILLS_JSON"
+    run jq -r '[.recommended_skills[] | select(.skill == "grill-with-docs")][0].repo' "$RECOMMEND_SKILLS_JSON"
     [ "$status" -eq 0 ]
     [ "$output" = "mattpocock/skills" ]
 }
 
-@test "grill-me-with-docs entry has non-empty description" {
+@test "grill-with-docs entry has non-empty description" {
     if ! command -v jq &>/dev/null; then
         skip "jq not installed"
     fi
-    run jq -r '[.recommended_skills[] | select(.skill == "grill-me-with-docs")][0].description' "$RECOMMEND_SKILLS_JSON"
+    run jq -r '[.recommended_skills[] | select(.skill == "grill-with-docs")][0].description' "$RECOMMEND_SKILLS_JSON"
     [ "$status" -eq 0 ]
     [ -n "$output" ]
 }
 
-@test "grill-me-with-docs description mentions docs-grounded or stress-test" {
+@test "grill-with-docs description mentions docs-grounded or stress-test" {
     if ! command -v jq &>/dev/null; then
         skip "jq not installed"
     fi
-    run jq -r '[.recommended_skills[] | select(.skill == "grill-me-with-docs")][0].description' "$RECOMMEND_SKILLS_JSON"
+    run jq -r '[.recommended_skills[] | select(.skill == "grill-with-docs")][0].description' "$RECOMMEND_SKILLS_JSON"
     [ "$status" -eq 0 ]
     [[ "$output" == *"docs"* ]] || [[ "$output" == *"stress"* ]]
 }
@@ -172,8 +172,8 @@ README_FILE="$REPO_ROOT/README.md"
 # README.md – install command content tests
 # ---------------------------------------------------------------------------
 
-@test "README.md install block contains grill-me-with-docs install command" {
-    run grep -F 'npx skills add mattpocock/skills --skill grill-me-with-docs' "$README_FILE"
+@test "README.md install block contains grill-with-docs install command" {
+    run grep -F 'npx skills add mattpocock/skills --skill grill-with-docs' "$README_FILE"
     [ "$status" -eq 0 ]
 }
 
@@ -188,14 +188,14 @@ README_FILE="$REPO_ROOT/README.md"
     run grep -F 'mattpocock/skills --skill grill-me' "$README_FILE"
     # grep should find the lines – verify they only reference the new skill names
     if [ "$status" -eq 0 ]; then
-        # output must not contain a line ending exactly in 'grill-me' (not grill-me-with-docs)
+        # output must not contain a line ending exactly in 'grill-me' (not grill-with-docs)
         echo "$output" | grep -qP '\bgrill-me\b(?!-)' && return 1 || return 0
     fi
     return 0
 }
 
-@test "README.md Matt Pocock table row references grill-me-with-docs" {
-    run grep -F 'grill-me-with-docs' "$README_FILE"
+@test "README.md Matt Pocock table row references grill-with-docs" {
+    run grep -F 'grill-with-docs' "$README_FILE"
     [ "$status" -eq 0 ]
     [[ "$output" == *"mattpocock"* ]]
 }


### PR DESCRIPTION
## What

Adds [Orca](https://onOrca.dev) — a next-gen desktop IDE for orchestrating AI coding agents — to the tools section of README.md.

## Why

Orca provides worktree isolation, multi-agent terminals, and built-in source control for AI coding workflows. Issue #204 requested adding it to the README for discoverability.

## How

- Added an entry under the existing tools section with a brief description, link, and brew install command
- Follows the same format as other tool entries

Closes #204

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Orca tool documentation with installation instructions
  * Added functional testing guide for BATS with prerequisites and instructions
  * Added PR review skill documentation with three input methods and workflow explanation

* **Tests**
  * Updated test suite for skill naming changes

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jellydn/my-ai-tools/pull/205)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->