### PR TITLE
feat(memory): add agentmemory section and canonical docs reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .antigravitycli/
 .claude/settings.local.json
 configs/ccs/cliproxy/accounts.json
+
+# agentmemory runtime state (created by `npx @agentmemory/agentmemory` at the repo root)
+data/
 configs/ccs/cliproxy/config.yaml
 configs/ccs/cliproxy/sessions.json
 configs/ccs/cliproxy/auth/antigravity-dunghd_it_gmail_com.json

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -88,6 +88,45 @@ echo "  Storage: ~/.ai-knowledges/$PROJECT_NAME"
 
 ---
 
+## 🧠 Agentmemory (session memory MCP)
+
+`agentmemory` is a per-session, per-project memory MCP for **short-lived learnings that the agent itself discovered during the current run**. It complements qmd — do not use it as a duplicate knowledge store.
+
+### Use `agentmemory` for
+
+- Discoveries made in _this_ session: "I learned that…", "The fix was…", "Don't forget to…"
+- Project-local facts the next agent on this project should know
+- Recurring gotchas worth surfacing when similar code or errors appear
+- Pre-commit/post-commit style findings, code review notes, architecture smells
+
+### Do NOT use `agentmemory` for
+
+- Anything already covered by qmd (durable project KB at `~/.ai-knowledges/<project>/`)
+- Long-form docs, ADRs, runbooks — write those to disk and let qmd index them
+- Cross-project or cross-machine knowledge — qmd collections are the canonical layer
+- Secrets, tokens, or anything user-private (memory is per-project, not encrypted)
+
+### Quick reference
+
+| Task                     | Tool                                               |
+| ------------------------ | -------------------------------------------------- |
+| Save a finding           | `mcp__agentmemory__memory_save`                    |
+| Recall past findings     | `mcp__agentmemory__memory_recall`                  |
+| Hybrid recall + rerank   | `mcp__agentmemory__memory_smart_search`            |
+| List recent sessions     | `mcp__agentmemory__memory_sessions`                |
+| Export / audit memory    | `mcp__agentmemory__memory_export` / `memory_audit` |
+| Delete a specific memory | `mcp__agentmemory__memory_governance_delete`       |
+
+### Decision rule
+
+> "Will the next agent working on this project benefit from this in 3 months?"
+>
+> - **Yes** → qmd (`/qmd-knowledge` skill)
+> - **No, but the next session today might** → `agentmemory.memory_save`
+> - **No at all** → don't record
+
+---
+
 ## 🛠️ How to Use qmd (via MCP Server)
 
 When qmd MCP server is configured, you can autonomously:

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -1,6 +1,6 @@
 # 🚀 MEMORY.md - AI Agent Knowledge Management
 
-**Purpose**: Tell agents when and how to use qmd for persistent knowledge capture.
+**Purpose**: Tell agents when to use **qmd** (durable project KB), when to use **agentmemory** (session-only learnings), and when to skip recording entirely. Cross-session task continuity goes through `/handoffs` + `/pickup`, not these stores.
 
 ---
 
@@ -90,40 +90,41 @@ echo "  Storage: ~/.ai-knowledges/$PROJECT_NAME"
 
 ## 🧠 Agentmemory (session memory MCP)
 
-`agentmemory` is a per-session, per-project memory MCP for **short-lived learnings that the agent itself discovered during the current run**. It complements qmd — do not use it as a duplicate knowledge store.
+`agentmemory` is a per-session, per-project memory MCP for **short-lived learnings that the agent itself discovered during the current run**. It is _not_ durable storage and _not_ a substitute for qmd.
 
-### Use `agentmemory` for
+### Use `agentmemory` for (session-only, not durable)
 
-- Discoveries made in _this_ session: "I learned that…", "The fix was…", "Don't forget to…"
-- Project-local facts the next agent on this project should know
-- Recurring gotchas worth surfacing when similar code or errors appear
-- Pre-commit/post-commit style findings, code review notes, architecture smells
+- Discoveries made in _this_ run: "the build is blocked on env var `X`", "branch Y has a WIP constraint", "the failing test depends on fixture Z"
+- Pre-commit / post-commit style findings the _current_ agent wants to surface to itself on the next pass
+- Hints the next session today will need but no one will need in a month
 
 ### Do NOT use `agentmemory` for
 
-- Anything already covered by qmd (durable project KB at `~/.ai-knowledges/<project>/`)
-- Long-form docs, ADRs, runbooks — write those to disk and let qmd index them
+- Anything that survives a session boundary with value — that is qmd
+- Recurring gotchas, project-local facts, architecture smells, code review notes — these are durable and belong in qmd
+- Long-form docs, ADRs, runbooks — write to disk and let qmd index them
 - Cross-project or cross-machine knowledge — qmd collections are the canonical layer
+- Cross-session task continuity — use `/handoffs` (write) and `/pickup` (resume), not agentmemory
 - Secrets, tokens, or anything user-private (memory is per-project, not encrypted)
 
-### Quick reference
-
-| Task                     | Tool                                               |
-| ------------------------ | -------------------------------------------------- |
-| Save a finding           | `mcp__agentmemory__memory_save`                    |
-| Recall past findings     | `mcp__agentmemory__memory_recall`                  |
-| Hybrid recall + rerank   | `mcp__agentmemory__memory_smart_search`            |
-| List recent sessions     | `mcp__agentmemory__memory_sessions`                |
-| Export / audit memory    | `mcp__agentmemory__memory_export` / `memory_audit` |
-| Delete a specific memory | `mcp__agentmemory__memory_governance_delete`       |
-
-### Decision rule
+### Decision rule (apply before every record)
 
 > "Will the next agent working on this project benefit from this in 3 months?"
 >
-> - **Yes** → qmd (`/qmd-knowledge` skill)
-> - **No, but the next session today might** → `agentmemory.memory_save`
+> - **Yes** → `mcp__qmd__*` (`/qmd-knowledge` skill)
+> - **No, but the next session today might** → `mcp__agentmemory__memory_save`
 > - **No at all** → don't record
+> - **"I need to keep working on this tomorrow"** → write a `/handoffs` plan, not a memory note
+
+### Three memory lanes
+
+| Lane          | Horizon             | Tool                                              |
+| ------------- | ------------------- | ------------------------------------------------- |
+| `qmd`         | Months              | `mcp__qmd__save` via `/qmd-knowledge` skill       |
+| `agentmemory` | Today, same project | `mcp__agentmemory__memory_save`                   |
+| `/handoffs`   | Cross-session task  | `/handoffs` slash command → resume with `/pickup` |
+
+If you find yourself wanting both "remember this for me next time" and "let me continue this tomorrow" — that is two separate stores; pick the lane that matches the actual horizon.
 
 ---
 
@@ -171,22 +172,22 @@ Instead, use the `qmd-knowledge` skill:
 
 At the end of a work session, consider prompting the user about key learnings:
 
-> "What were the main discoveries or decisions from this session? Would you like me to record any learnings?"
+> "What were the main discoveries or decisions from this session? Would you like me to record any learnings — and if so, into qmd (durable) or agentmemory (session)?"
 
-### 🎨 Pattern Detection
+### 🎨 Pattern Detection → Decision Rule
 
-Be attentive to phrases that indicate valuable knowledge capture opportunities:
+When you spot a knowledge-capture trigger, **apply the 3-month rule first**, then choose a lane.
 
-- "I discovered that..."
-- "I learned that..."
-- "The solution was..."
-- "The key insight is..."
-- "Don't forget to..."
-- "Make sure to..."
+| Phrase                                       | Lane                                    |
+| -------------------------------------------- | --------------------------------------- |
+| "I learned that…" / "The fix was…" (general) | Usually qmd — unless it is session-only |
+| "Blocked on X until env var Y"               | `agentmemory` (session)                 |
+| "Branch W has a WIP constraint"              | `agentmemory` (session)                 |
+| "Don't forget to…" / recurring gotcha        | qmd (durable)                           |
+| "This project uses pattern P"                | qmd (durable, project-local)            |
+| "Continue debugging tomorrow" / "resume X"   | `/handoffs` + `/pickup` (not memory)    |
 
-When you detect these patterns, suggest recording:
-
-> "That sounds like a useful learning. Would you like me to record it?"
+If unsure, ask the user which lane — never record into both.
 
 ### 🎨 Auto-Index Updates
 
@@ -196,12 +197,28 @@ The record script automatically runs `qmd embed` after each write, ensuring the 
 
 ## 📖 Quick Reference
 
+All tools are MCP-style names so agents can call them by exact string.
+
+### qmd (durable)
+
 | Task             | Tool/Command           |
 | ---------------- | ---------------------- |
 | Search knowledge | `mcp__qmd__query`      |
 | Get document     | `mcp__qmd__get`        |
 | Record learning  | `/qmd-knowledge` skill |
 | Check status     | `mcp__qmd__status`     |
+
+### agentmemory (session)
+
+| Task                     | Tool                                         |
+| ------------------------ | -------------------------------------------- |
+| Save a finding           | `mcp__agentmemory__memory_save`              |
+| Recall past findings     | `mcp__agentmemory__memory_recall`            |
+| Hybrid recall + rerank   | `mcp__agentmemory__memory_smart_search`      |
+| List recent sessions     | `mcp__agentmemory__memory_sessions`          |
+| Export memory            | `mcp__agentmemory__memory_export`            |
+| Audit memory             | `mcp__agentmemory__memory_audit`             |
+| Delete a specific memory | `mcp__agentmemory__memory_governance_delete` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@
 
 ### 📋 MCP Server Details
 
-| Server                | Purpose                                                              | Package                                            |
-| --------------------- | -------------------------------------------------------------------- | -------------------------------------------------- |
-| `context7`            | Documentation lookup for any library                                 | `@upstash/context7-mcp`                            |
-| `sequential-thinking` | Multi-step reasoning for complex analysis                            | `@modelcontextprotocol/server-sequential-thinking` |
-| `qmd`                 | Knowledge management with AI-powered search                          | `qmd`                                              |
-| `agentmemory`         | Session memory for AI coding agents (qmd = durable; see `MEMORY.md`) | `@agentmemory/mcp`                                 |
-| `fff`                 | Fast file search with frecency ranking                               | `fff-mcp`                                          |
-| `react-grab-mcp`      | React component capture and inspection                               | `@react-grab/mcp`                                  |
-| `logpilot`            | AI-powered log analysis and tmux monitoring                          | `logpilot`                                         |
+| Server                | Purpose                                                                                   | Package                                            |
+| --------------------- | ----------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| `context7`            | Documentation lookup for any library                                                      | `@upstash/context7-mcp`                            |
+| `sequential-thinking` | Multi-step reasoning for complex analysis                                                 | `@modelcontextprotocol/server-sequential-thinking` |
+| `qmd`                 | Knowledge management with AI-powered search                                               | `qmd`                                              |
+| `agentmemory`         | "Persistent memory" per the tool; we use it session-only (qmd = durable; see `MEMORY.md`) | `@agentmemory/mcp`                                 |
+| `fff`                 | Fast file search with frecency ranking                                                    | `fff-mcp`                                          |
+| `react-grab-mcp`      | React component capture and inspection                                                    | `@react-grab/mcp`                                  |
+| `logpilot`            | AI-powered log analysis and tmux monitoring                                               | `logpilot`                                         |
 
 ## 🎬 Demo
 
@@ -212,7 +212,7 @@ The script will prompt you to install each MCP server:
 - [`context7`](https://github.com/upstash/context7) - Documentation lookup for any library
 - [`sequential-thinking`](https://mcp.so/server/sequentialthinking) - Multi-step reasoning for complex analysis
 - [`qmd`](https://github.com/tobi/qmd) - Quick Markdown Search with AI-powered knowledge management
-- [`agentmemory`](https://github.com/rohitg00/agentmemory) - Session memory for AI coding agents (qmd is the durable KB; see `~/.ai-tools/MEMORY.md`)
+- [`agentmemory`](https://github.com/rohitg00/agentmemory) - "Persistent memory" per the tool's branding; we use it session-only (qmd is the durable KB; see `~/.ai-tools/MEMORY.md`)
 - [`fff`](https://github.com/dmtrKovalenko/fff.nvim) - Fast file search with built-in memory for AI agents
 - [`react-grab-mcp`](https://github.com/nyan-left/react-grab-mcp) - React component extraction and analysis
 - [`logpilot`](https://github.com/jellydn/logpilot) - AI-powered log analysis and tmux session monitoring

--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@
 
 ### 📋 MCP Server Details
 
-| Server                | Purpose                                     | Package                                            |
-| --------------------- | ------------------------------------------- | -------------------------------------------------- |
-| `context7`            | Documentation lookup for any library        | `@upstash/context7-mcp`                            |
-| `sequential-thinking` | Multi-step reasoning for complex analysis   | `@modelcontextprotocol/server-sequential-thinking` |
-| `qmd`                 | Knowledge management with AI-powered search | `qmd`                                              |
-| `agentmemory`         | Persistent memory for AI coding agents      | `@agentmemory/mcp`                                 |
-| `fff`                 | Fast file search with frecency ranking      | `fff-mcp`                                          |
-| `react-grab-mcp`      | React component capture and inspection      | `@react-grab/mcp`                                  |
-| `logpilot`            | AI-powered log analysis and tmux monitoring | `logpilot`                                         |
+| Server                | Purpose                                                              | Package                                            |
+| --------------------- | -------------------------------------------------------------------- | -------------------------------------------------- |
+| `context7`            | Documentation lookup for any library                                 | `@upstash/context7-mcp`                            |
+| `sequential-thinking` | Multi-step reasoning for complex analysis                            | `@modelcontextprotocol/server-sequential-thinking` |
+| `qmd`                 | Knowledge management with AI-powered search                          | `qmd`                                              |
+| `agentmemory`         | Session memory for AI coding agents (qmd = durable; see `MEMORY.md`) | `@agentmemory/mcp`                                 |
+| `fff`                 | Fast file search with frecency ranking                               | `fff-mcp`                                          |
+| `react-grab-mcp`      | React component capture and inspection                               | `@react-grab/mcp`                                  |
+| `logpilot`            | AI-powered log analysis and tmux monitoring                          | `logpilot`                                         |
 
 ## 🎬 Demo
 
@@ -212,7 +212,7 @@ The script will prompt you to install each MCP server:
 - [`context7`](https://github.com/upstash/context7) - Documentation lookup for any library
 - [`sequential-thinking`](https://mcp.so/server/sequentialthinking) - Multi-step reasoning for complex analysis
 - [`qmd`](https://github.com/tobi/qmd) - Quick Markdown Search with AI-powered knowledge management
-- [`agentmemory`](https://github.com/rohitg00/agentmemory) - Persistent memory for AI coding agents
+- [`agentmemory`](https://github.com/rohitg00/agentmemory) - Session memory for AI coding agents (qmd is the durable KB; see `~/.ai-tools/MEMORY.md`)
 - [`fff`](https://github.com/dmtrKovalenko/fff.nvim) - Fast file search with built-in memory for AI agents
 - [`react-grab-mcp`](https://github.com/nyan-left/react-grab-mcp) - React component extraction and analysis
 - [`logpilot`](https://github.com/jellydn/logpilot) - AI-powered log analysis and tmux session monitoring

--- a/configs/amp/AGENTS.md
+++ b/configs/amp/AGENTS.md
@@ -23,6 +23,7 @@ See @~/.ai-tools/best-practices.md for full details.
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
+- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## General Practices

--- a/configs/amp/AGENTS.md
+++ b/configs/amp/AGENTS.md
@@ -23,13 +23,12 @@ See @~/.ai-tools/best-practices.md for full details.
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
-- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## General Practices
 
 - Follow my software development practice @~/.ai-tools/best-practices.md
-- Read @~/.ai-tools/MEMORY.md first - Understand when and how to use qmd for knowledge management
+- Read @~/.ai-tools/MEMORY.md first — qmd (durable) vs agentmemory (session); follow the decision rule there
 - Follow git safety guidelines @~/.ai-tools/git-guidelines.md
 - Keep responses concise and actionable.
 - Always propose a plan before edits. Use phases to break down tasks into manageable steps.

--- a/configs/antigravity-cli/plugins/my-ai-tools-gemini-migration/rules/AGENTS.md
+++ b/configs/antigravity-cli/plugins/my-ai-tools-gemini-migration/rules/AGENTS.md
@@ -25,13 +25,12 @@ See @~/.ai-tools/best-practices.md for full details.
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
-- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## General Practices
 
 - Follow my software development practice @~/.ai-tools/best-practices.md
-- Read @~/.ai-tools/MEMORY.md first - Understand when and how to use qmd for knowledge management
+- Read @~/.ai-tools/MEMORY.md first — qmd (durable) vs agentmemory (session); follow the decision rule there
 - Follow git safety guidelines @~/.ai-tools/git-guidelines.md
 - Keep responses concise and actionable.
 - Always propose a plan before edits. Use phases to break down tasks into manageable steps.

--- a/configs/antigravity-cli/plugins/my-ai-tools-gemini-migration/rules/AGENTS.md
+++ b/configs/antigravity-cli/plugins/my-ai-tools-gemini-migration/rules/AGENTS.md
@@ -25,6 +25,7 @@ See @~/.ai-tools/best-practices.md for full details.
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
+- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## General Practices

--- a/configs/antigravity-cli/plugins/my-ai-tools-gemini-migration/rules/GEMINI.md
+++ b/configs/antigravity-cli/plugins/my-ai-tools-gemini-migration/rules/GEMINI.md
@@ -3,6 +3,7 @@
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
+- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 
 ## General Practices
 

--- a/configs/antigravity-cli/plugins/my-ai-tools-gemini-migration/rules/GEMINI.md
+++ b/configs/antigravity-cli/plugins/my-ai-tools-gemini-migration/rules/GEMINI.md
@@ -3,12 +3,11 @@
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
-- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 
 ## General Practices
 
 - Follow my software development practice @~/.ai-tools/best-practices.md
-- Read @~/.ai-tools/MEMORY.md first - Understand when and how to use qmd for knowledge management
+- Read @~/.ai-tools/MEMORY.md first — qmd (durable) vs agentmemory (session); follow the decision rule there
 - Keep responses concise and actionable.
 - Always propose a plan before edits. Use phases to break down tasks into manageable steps.
 - Run typecheck, lint and biome on js/ts file changes after finish

--- a/configs/claude/CLAUDE.md
+++ b/configs/claude/CLAUDE.md
@@ -27,13 +27,12 @@ See @~/.ai-tools/best-practices.md for full details.
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
-- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## General Practices
 
 - Follow my software development practice @~/.ai-tools/best-practices.md
-- Read @~/.ai-tools/MEMORY.md first - Understand when and how to use qmd for knowledge management
+- Read @~/.ai-tools/MEMORY.md first — qmd (durable) vs agentmemory (session); follow the decision rule there
 - Keep responses concise and actionable.
 - Always propose a plan before edits. Use phases to break down tasks into manageable steps.
 - Run typecheck, lint and biome on js/ts file changes after finish

--- a/configs/claude/CLAUDE.md
+++ b/configs/claude/CLAUDE.md
@@ -27,6 +27,7 @@ See @~/.ai-tools/best-practices.md for full details.
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
+- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## General Practices

--- a/configs/codex/AGENTS.md
+++ b/configs/codex/AGENTS.md
@@ -23,6 +23,7 @@ See @~/.ai-tools/best-practices.md for full details.
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
+- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## General Practices

--- a/configs/codex/AGENTS.md
+++ b/configs/codex/AGENTS.md
@@ -23,13 +23,12 @@ See @~/.ai-tools/best-practices.md for full details.
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
-- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## General Practices
 
 - Follow my software development practice @~/.ai-tools/best-practices.md
-- Read @~/.ai-tools/MEMORY.md first - Understand when and how to use qmd for knowledge management
+- Read @~/.ai-tools/MEMORY.md first — qmd (durable) vs agentmemory (session); follow the decision rule there
 - Follow git safety guidelines @~/.ai-tools/git-guidelines.md
 - Keep responses concise and actionable.
 - Always propose a plan before edits. Use phases to break down tasks into manageable steps.

--- a/configs/commandcode/AGENTS.md
+++ b/configs/commandcode/AGENTS.md
@@ -23,13 +23,12 @@ See @~/.ai-tools/best-practices.md for full details.
 ## 🛠️ AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
-- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## 📋 General Practices
 
 - Follow my software development practice @~/.ai-tools/best-practices.md
-- Read @~/.ai-tools/MEMORY.md first — Understand when and how to use qmd for knowledge management
+- Read @~/.ai-tools/MEMORY.md first — qmd (durable) vs agentmemory (session); follow the decision rule there
 - Follow git safety guidelines @~/.ai-tools/git-guidelines.md
 - Keep responses concise and actionable.
 - Never run destructive commands.

--- a/configs/commandcode/AGENTS.md
+++ b/configs/commandcode/AGENTS.md
@@ -23,6 +23,7 @@ See @~/.ai-tools/best-practices.md for full details.
 ## 🛠️ AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
+- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## 📋 General Practices

--- a/configs/copilot/AGENTS.md
+++ b/configs/copilot/AGENTS.md
@@ -25,6 +25,7 @@ See @~/.ai-tools/best-practices.md for full details.
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
+- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## General Practices

--- a/configs/copilot/AGENTS.md
+++ b/configs/copilot/AGENTS.md
@@ -25,13 +25,12 @@ See @~/.ai-tools/best-practices.md for full details.
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
-- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## General Practices
 
 - Follow my software development practice @~/.ai-tools/best-practices.md
-- Read @~/.ai-tools/MEMORY.md first - Understand when and how to use qmd for knowledge management
+- Read @~/.ai-tools/MEMORY.md first — qmd (durable) vs agentmemory (session); follow the decision rule there
 - Follow git safety guidelines @~/.ai-tools/git-guidelines.md
 - Keep responses concise and actionable.
 - Never run destructive commands.

--- a/configs/cursor/AGENTS.md
+++ b/configs/cursor/AGENTS.md
@@ -23,6 +23,7 @@ See @~/.ai-tools/best-practices.md for full details.
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
+- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## General Practices

--- a/configs/cursor/AGENTS.md
+++ b/configs/cursor/AGENTS.md
@@ -23,13 +23,12 @@ See @~/.ai-tools/best-practices.md for full details.
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
-- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## General Practices
 
 - Follow my software development practice @~/.ai-tools/best-practices.md
-- Read @~/.ai-tools/MEMORY.md first - Understand when and how to use qmd for knowledge management
+- Read @~/.ai-tools/MEMORY.md first — qmd (durable) vs agentmemory (session); follow the decision rule there
 - Follow git safety guidelines @~/.ai-tools/git-guidelines.md
 - Keep responses concise and actionable.
 - Never run destructive commands.

--- a/configs/factory/AGENTS.md
+++ b/configs/factory/AGENTS.md
@@ -23,6 +23,7 @@ See @~/.ai-tools/best-practices.md for full details.
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
+- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## General Practices

--- a/configs/factory/AGENTS.md
+++ b/configs/factory/AGENTS.md
@@ -23,13 +23,12 @@ See @~/.ai-tools/best-practices.md for full details.
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
-- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## General Practices
 
 - Follow my software development practice @~/.ai-tools/best-practices.md
-- Read @~/.ai-tools/MEMORY.md first - Understand when and how to use qmd for knowledge management
+- Read @~/.ai-tools/MEMORY.md first — qmd (durable) vs agentmemory (session); follow the decision rule there
 - Follow git safety guidelines @~/.ai-tools/git-guidelines.md
 - Keep responses concise and actionable.
 - Never run destructive commands.

--- a/configs/gemini/AGENTS.md
+++ b/configs/gemini/AGENTS.md
@@ -25,13 +25,12 @@ See @~/.ai-tools/best-practices.md for full details.
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
-- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## General Practices
 
 - Follow my software development practice @~/.ai-tools/best-practices.md
-- Read @~/.ai-tools/MEMORY.md first - Understand when and how to use qmd for knowledge management
+- Read @~/.ai-tools/MEMORY.md first — qmd (durable) vs agentmemory (session); follow the decision rule there
 - Follow git safety guidelines @~/.ai-tools/git-guidelines.md
 - Keep responses concise and actionable.
 - Always propose a plan before edits. Use phases to break down tasks into manageable steps.

--- a/configs/gemini/AGENTS.md
+++ b/configs/gemini/AGENTS.md
@@ -25,6 +25,7 @@ See @~/.ai-tools/best-practices.md for full details.
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
+- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## General Practices

--- a/configs/gemini/GEMINI.md
+++ b/configs/gemini/GEMINI.md
@@ -3,6 +3,7 @@
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
+- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 
 ## General Practices
 

--- a/configs/gemini/GEMINI.md
+++ b/configs/gemini/GEMINI.md
@@ -3,12 +3,11 @@
 ## AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
-- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 
 ## General Practices
 
 - Follow my software development practice @~/.ai-tools/best-practices.md
-- Read @~/.ai-tools/MEMORY.md first - Understand when and how to use qmd for knowledge management
+- Read @~/.ai-tools/MEMORY.md first — qmd (durable) vs agentmemory (session); follow the decision rule there
 - Keep responses concise and actionable.
 - Always propose a plan before edits. Use phases to break down tasks into manageable steps.
 - Run typecheck, lint and biome on js/ts file changes after finish

--- a/configs/kilo/AGENTS.md
+++ b/configs/kilo/AGENTS.md
@@ -23,13 +23,12 @@ See @~/.ai-tools/best-practices.md for full details.
 ## 🔧 AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
-- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## 📋 General Practices
 
 - Follow my software development practice @~/.ai-tools/best-practices.md
-- Read @~/.ai-tools/MEMORY.md first - Understand when and how to use qmd for knowledge management
+- Read @~/.ai-tools/MEMORY.md first — qmd (durable) vs agentmemory (session); follow the decision rule there
 - Follow git safety guidelines @~/.ai-tools/git-guidelines.md
 - Keep responses concise and actionable.
 - Never run destructive commands.

--- a/configs/kilo/AGENTS.md
+++ b/configs/kilo/AGENTS.md
@@ -23,6 +23,7 @@ See @~/.ai-tools/best-practices.md for full details.
 ## 🔧 AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
+- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## 📋 General Practices

--- a/configs/pi/AGENTS.md
+++ b/configs/pi/AGENTS.md
@@ -23,13 +23,12 @@ See @~/.ai-tools/best-practices.md for full details.
 ## 🔧 AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
-- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## 📋 General Practices
 
 - Follow my software development practice @~/.ai-tools/best-practices.md
-- Read @~/.ai-tools/MEMORY.md first - Understand when and how to use qmd for knowledge management
+- Read @~/.ai-tools/MEMORY.md first — qmd (durable) vs agentmemory (session); follow the decision rule there
 - Follow git safety guidelines @~/.ai-tools/git-guidelines.md
 - Keep responses concise and actionable.
 - Never run destructive commands.

--- a/configs/pi/AGENTS.md
+++ b/configs/pi/AGENTS.md
@@ -23,6 +23,7 @@ See @~/.ai-tools/best-practices.md for full details.
 ## 🔧 AI Tool Guidelines
 
 - Use the fff MCP tools for all file search operations instead of default tools.
+- For persistent memory (qmd + agentmemory), follow @~/.ai-tools/MEMORY.md
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## 📋 General Practices


### PR DESCRIPTION
## What

Document the **qmd vs agentmemory** split in `MEMORY.md` and align all instruction files to a single canonical reference.

- `MEMORY.md` — new "🧠 Agentmemory (session memory MCP)" section, three-memory-lanes table (qmd / agentmemory / handoffs), decision rule, unified quick-reference, and a Pattern Detection table mapped to lanes
- 13 × `AGENTS.md` / `CLAUDE.md` / `GEMINI.md` — single canonical reference line in each file's General Practices section, pointing to `~/.ai-tools/MEMORY.md`
- `README.md` — `agentmemory` blurb corrected from "Persistent memory" to "Session memory (qmd = durable; see `MEMORY.md`)" in two places

Synced `MEMORY.md` to `~/.ai-tools/MEMORY.md`.

## Why

Agents were previously told to "use agentmemory for learning and findings" in 13 files with no guidance on when to use it vs `qmd`, and `agentmemory` itself was described as "Persistent memory" in the README — guaranteeing duplicate writes and contradictory memory decisions. This change:

- Documents the qmd (durable) vs agentmemory (session) vs handoffs (cross-session task) lanes
- Funnels all 13 instruction files to a single canonical reference
- Aligns README wording with the new model

## How

Four atomic commits per the PR review feedback:

1. **`docs(memory): document agentmemory in MEMORY.md`** — initial Agentmemory section
2. **`chore(configs): point AGENTS docs to canonical MEMORY.md`** — adds a new "AI Tool Guidelines" bullet pointing to MEMORY.md
3. **`fix(memory): address PR review feedback on agentmemory docs`** (after review) — tightens "use for" to session-only, adds handoffs boundary, unifies the two quick-reference tables, aligns Pattern Detection with the decision rule, fixes inconsistent tool naming (`mcp__qmd__*` / `mcp__agentmemory__*` everywhere), updates the file header
4. **`fix(configs): drop duplicate MEMORY bullet from instruction files`** (after review) — removes the new "AI Tool Guidelines" bullet added in commit 2; updates the existing "General Practices" line in each file to be the single canonical reference with correct wording

### Decision rule (now consistent across all docs)

> Will the next agent working on this project benefit from this in 3 months?
>
> - **Yes** → qmd (`mcp__qmd__*` via `/qmd-knowledge` skill)
> - **No, but the next session today might** → `mcp__agentmemory__memory_save`
> - **No at all** → don't record
> - **"I need to keep working on this tomorrow"** → write a `/handoffs` plan, not a memory note

### Three memory lanes

| Lane          | Horizon             | Tool                                              |
| ------------- | ------------------- | ------------------------------------------------- |
| `qmd`         | Months              | `mcp__qmd__save` via `/qmd-knowledge` skill       |
| `agentmemory` | Today, same project | `mcp__agentmemory__memory_save`                   |
| `/handoffs`   | Cross-session task  | `/handoffs` slash command → resume with `/pickup` |

## Excluded (machine-local, not in repo)

These were synced locally and reverted from the PR to keep the repo portable:

- `~/.codex/` `[projects."/Users/huynhdung/..."]` trust entries
- `~/.gemini/antigravity-cli/` `trustedWorkspaces` and `unsandboxed(...)` allowlist entries
- `~/.pi/agent/` model/provider/package preferences

## Checklist

- [x] Documentation updated (`MEMORY.md` + 13 instruction files + `README.md`)
- [x] No breaking changes
- [x] Pre-commit hooks pass (`prek`: trim whitespace, fix end of files, prettier, large files)
- [x] `bash -n` passes on `cli.sh` / `generate.sh` / `install.sh` / `lib/common.sh`
- [x] `jq .` passes on all JSON configs
- [x] No hardcoded paths (`/Users/huynhdung`) in the diff
- [x] No broken shell quoting in hook commands
- [x] No "persistent" mislabeling of agentmemory
- [x] No duplicate `MEMORY.md` references per instruction file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified memory storage guidance across three lanes: durable project knowledge (qmd), session-only memory (agentmemory), and cross-session continuity (/handoffs + /pickup).
  * Added decision rules and a pattern detection table to help determine appropriate storage for different types of information.
  * Updated agent configuration documentation to reference the new memory management framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->