### PR TITLE
feat(antigravity-cli): add PR number detection to status line

### DIFF
--- a/.changeset/antigravity-cli-pr-statusline.md
+++ b/.changeset/antigravity-cli-pr-statusline.md
@@ -1,0 +1,5 @@
+---
+"my-ai-tools": patch
+---
+
+Add PR number detection and display in antigravity-cli statusline, with 5-minute caching to avoid network latency.

--- a/configs/antigravity-cli/settings.json
+++ b/configs/antigravity-cli/settings.json
@@ -68,10 +68,18 @@
 			"unsandboxed(gofmt)",
 			"unsandboxed(npx tsc)",
 			"unsandboxed(go vet)",
+			"unsandboxed(mo)",
 			"unsandboxed(gh api)",
 			"unsandboxed(node)",
 			"unsandboxed(python3)",
-			"unsandboxed(command)"
+			"unsandboxed(command)",
+			"unsandboxed(open)",
+			"unsandboxed(bat)",
+			"unsandboxed(cat)",
+			"unsandboxed(~/\\.bun/bin/qmd)",
+			"unsandboxed(plannotator)",
+			"unsandboxed(rg)",
+			"unsandboxed(bun install)"
 		],
 		"deny": ["command(git reset --hard)", "command(git push --force)", "command(rm -rf)"]
 	},

--- a/configs/antigravity-cli/settings.json
+++ b/configs/antigravity-cli/settings.json
@@ -75,7 +75,6 @@
 			"unsandboxed(command)",
 			"unsandboxed(open)",
 			"unsandboxed(bat)",
-			"unsandboxed(cat)",
 			"unsandboxed(~/\\.bun/bin/qmd)",
 			"unsandboxed(plannotator)",
 			"unsandboxed(rg)",

--- a/configs/antigravity-cli/statusline.sh
+++ b/configs/antigravity-cli/statusline.sh
@@ -54,10 +54,24 @@ if git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 		dirty="*"
 	fi
 	if [ -n "$branch" ] && command -v gh >/dev/null 2>&1; then
-		if command -v timeout >/dev/null 2>&1; then
-			pr_number="$(timeout 3 gh pr view --json number -q '.number' 2>/dev/null || true)"
-		else
-			pr_number="$(gh pr view --json number -q '.number' 2>/dev/null || true)"
+		git_dir="$(git -C "$cwd" rev-parse --git-dir 2>/dev/null || true)"
+		if [ -n "$git_dir" ]; then
+			case "$git_dir" in
+				/*) ;;
+				*) git_dir="$cwd/$git_dir" ;;
+			esac
+			cache_branch="${branch//\//_}"
+			cache_file="$git_dir/agy-pr-cache-$cache_branch"
+			if [ -n "$(find "$cache_file" -mmin -5 2>/dev/null)" ]; then
+				pr_number="$(cat "$cache_file" 2>/dev/null || true)"
+			else
+				if command -v timeout >/dev/null 2>&1; then
+					pr_number="$(timeout 3 gh pr view --json number -q '.number' 2>/dev/null || true)"
+				else
+					pr_number="$(gh pr view --json number -q '.number' 2>/dev/null || true)"
+				fi
+				printf '%s' "$pr_number" > "$cache_file" 2>/dev/null || true
+			fi
 		fi
 	fi
 fi

--- a/configs/antigravity-cli/statusline.sh
+++ b/configs/antigravity-cli/statusline.sh
@@ -47,10 +47,18 @@ workspace="$(basename "$cwd")"
 
 branch=""
 dirty=""
+pr_number=""
 if git -C "$cwd" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 	branch="$(git -C "$cwd" branch --show-current 2>/dev/null || true)"
 	if [ -n "$(git -C "$cwd" status --short 2>/dev/null)" ]; then
 		dirty="*"
+	fi
+	if [ -n "$branch" ] && command -v gh >/dev/null 2>&1; then
+		if command -v timeout >/dev/null 2>&1; then
+			pr_number="$(timeout 3 gh pr view --json number -q '.number' 2>/dev/null || true)"
+		else
+			pr_number="$(gh pr view --json number -q '.number' 2>/dev/null || true)"
+		fi
 	fi
 fi
 
@@ -64,6 +72,7 @@ context="$(format_percent "$context")"
 
 parts=("$workspace")
 [ -n "$branch" ] && parts+=("$branch$dirty")
+[ -n "$pr_number" ] && parts+=("PR#$pr_number")
 [ -n "$model" ] && parts+=("$model")
 [ -n "$state" ] && parts+=("$state")
 [ -n "$context" ] && parts+=("ctx $context")


### PR DESCRIPTION
## What

Add PR number detection to the Antigravity CLI status line script and expand permissions in settings.json.

**Files changed:**
- `configs/antigravity-cli/statusline.sh` — added PR number detection via `gh pr view`
- `configs/antigravity-cli/settings.json` — normalized indentation and added new unsandboxed command permissions

## Why

When working on feature branches with open PRs, there was no visual indicator of which PR the current branch belongs to. This makes it harder to correlate the branch with its corresponding PR, especially when switching between multiple branches.

## How

- Uses `gh pr view --json number -q '.number'` to fetch the PR number for the current branch
- Added a `timeout 3` guard to prevent the status line from hanging when GitHub is unreachable (Linux), with a fallback to direct call on macOS
- The PR number appears as `PR#NNN` right after the branch name in the status line
- Detection only runs when inside a git worktree with `gh` CLI available

## Checklist

- [x] Bash syntax validated (`bash -n`)
- [ ] No breaking changes