### PR TITLE
Merge pull request #258 from jellydn/jellydn/atlanta

### DIFF
--- a/cli.sh
+++ b/cli.sh
@@ -898,6 +898,17 @@ copy_amp_configs() {
 		copy_config_file "$SCRIPT_DIR/configs/amp/AGENTS.md" "$HOME/.config/"
 	fi
 
+	# Copy plugins
+	if [ -d "$SCRIPT_DIR/configs/amp/plugins" ]; then
+		execute_quoted mkdir -p "$HOME/.config/amp/plugins"
+		for plugin_dir in "$SCRIPT_DIR/configs/amp/plugins"/*; do
+			[ -d "$plugin_dir" ] || continue
+			local plugin_name
+			plugin_name="$(basename "$plugin_dir")"
+			safe_copy_dir "$plugin_dir" "$HOME/.config/amp/plugins/$plugin_name"
+		done
+	fi
+
 	log_success "Amp configs copied"
 }
 

--- a/cli.sh
+++ b/cli.sh
@@ -175,72 +175,6 @@ check_prerequisites() {
 }
 
 
-# Helper: Safely copy a directory, handling "Text file busy" errors
-# Usage: safe_copy_dir "source_dir" "dest_dir"
-safe_copy_dir() {
-	local source_dir="$1"
-	local dest_dir="$2"
-	local skipped=0
-	local errors=0
-
-	if [ "$DRY_RUN" = true ]; then
-		log_info "[DRY RUN] Would copy $source_dir to $dest_dir"
-		return 0
-	fi
-
-	if ! mkdir -p "$(dirname "$dest_dir")" 2>/dev/null; then
-		log_warning "Failed to create destination directory: $(dirname "$dest_dir")"
-		return 1
-	fi
-
-	# Directories to exclude from copies
-	local -a exclude_dirs=(
-		"node_modules" "plugins" "projects" "debug" "sessions" "git"
-		"cache" "extensions" "chats" "antigravity" "antigravity-browser-profile"
-		"log" "logs" "tmp" "vendor_imports" "file-history" "ai-tracking"
-	)
-
-	# Prefer rsync when available
-	if command -v rsync &>/dev/null; then
-		local -a rsync_excludes=()
-		for dir in "${exclude_dirs[@]}"; do
-			rsync_excludes+=(--exclude "$dir" --exclude "$dir/**")
-		done
-		rsync_excludes+=(--exclude "*.sqlite" --exclude "*.sqlite-wal" --exclude "*.sqlite-shm")
-		if rsync -a --ignore-errors "${rsync_excludes[@]}" "$source_dir/" "$dest_dir/" 2>/dev/null; then
-			return 0
-		fi
-	fi
-
-	# Fallback: manual copy
-	local prune_expr=""
-	for dir in "${exclude_dirs[@]}"; do
-		prune_expr="$prune_expr -name $dir -o"
-	done
-	prune_expr="${prune_expr% -o}"
-
-	mkdir -p "$dest_dir"
-	# POSIX: use temp file instead of process substitution so the loop runs in the current shell
-	local _find_list
-	_find_list=$(make_temp_file "safe-copy-find" "list")
-	find "$source_dir" -type d \( $prune_expr \) -prune -o -type f -print 2>/dev/null > "$_find_list"
-	while IFS= read -r file; do
-		case "$file" in *.sqlite | *.sqlite-wal | *.sqlite-shm) continue ;; esac
-		local rel_path="${file#"$source_dir"/}"
-		local dest_file="$dest_dir/$rel_path"
-		mkdir -p "$(dirname "$dest_file")"
-		if ! cp "$file" "$dest_file" 2>/dev/null; then
-			((errors++))
-			((skipped++))
-			[ "$VERBOSE" = true ] && log_warning "Skipped busy file: $rel_path"
-		fi
-	done < "$_find_list"
-	rm -f "$_find_list"
-
-	[ "$VERBOSE" = true ] && [ $skipped -gt 0 ] && log_info "Skipped $skipped busy file(s)"
-	return 0
-}
-
 # Helper: Copy a config directory if it exists in source and destination
 # Usage: copy_config_dir "source_dir" "dest_parent" "dest_name"
 copy_config_dir() {
@@ -901,11 +835,15 @@ copy_amp_configs() {
 	# Copy plugins
 	if [ -d "$SCRIPT_DIR/configs/amp/plugins" ]; then
 		execute_quoted mkdir -p "$HOME/.config/amp/plugins"
+		local plugin_dir
 		for plugin_dir in "$SCRIPT_DIR/configs/amp/plugins"/*; do
-			[ -d "$plugin_dir" ] || continue
-			local plugin_name
-			plugin_name="$(basename "$plugin_dir")"
-			safe_copy_dir "$plugin_dir" "$HOME/.config/amp/plugins/$plugin_name"
+			if [ -d "$plugin_dir" ]; then
+				local plugin_name
+				plugin_name="$(basename "$plugin_dir")"
+				safe_copy_dir "$plugin_dir" "$HOME/.config/amp/plugins/$plugin_name"
+			elif [ -f "$plugin_dir" ]; then
+				copy_config_file "$plugin_dir" "$HOME/.config/amp/plugins"
+			fi
 		done
 	fi
 

--- a/configs/amp/plugins/glm-52-mode.ts
+++ b/configs/amp/plugins/glm-52-mode.ts
@@ -1,0 +1,161 @@
+// @amp-plugin updated automatically from https://ampcode.com/@amp/plugins/glm-52-mode.ts
+import type { PluginAPI } from "@ampcode/plugin";
+
+const GLM_52_AGENT_PROMPT = `
+You are a senior software engineer working directly in the user's codebase. You read code, plan, implement, and verify changes to satisfy the latest request, then report what changed and how you confirmed it.
+
+<operating_principles>
+- Treat the newest user message as the source of truth when instructions conflict.
+- For implementation requests, change code instead of describing what could be done.
+- Ask a question only when the missing answer changes the correct implementation; otherwise state the smallest safe assumption and proceed.
+- Preserve the user's changes and other agents' changes unless asked to alter them.
+- Prefer the smallest change that fully solves the requested behavior.
+- A task is done when the outcome is implemented, unrelated work is left untouched, and verification has passed or the blocker is stated plainly.
+</operating_principles>
+
+<frame_the_task>
+Before non-trivial work, settle four things, from the request or the codebase:
+- Goal: the concrete behavior to build, fix, or change.
+- Context: the files, functions, errors, or docs that define current behavior.
+- Constraints: repo conventions, architecture rules, dependency limits, security.
+- Done when: the observable signal of success (tests pass, bug no longer repros).
+</frame_the_task>
+
+<plan_before_acting>
+- For complex or multi-file work, think first: map the change, its blast radius, and the contracts to preserve, then implement against that plan.
+- Decompose long-horizon tasks into ordered steps and execute them deliberately; do not start editing before you know where the change belongs.
+- For risky refactors, decide the impact scope, risk boundaries, and how you will verify before changing a line.
+</plan_before_acting>
+
+<codebase_discovery>
+- Read the files that define the behavior before editing them.
+- Check nearby tests, call sites, and type definitions before changing shared contracts.
+- Use exact search for known names and semantic search for behavior-level questions.
+- Stop searching once you know where the change belongs and what contract to preserve.
+- Do not infer API behavior from memory when local code or documentation is available.
+</codebase_discovery>
+
+<tool_use>
+- Inspect, edit, and verify with tools instead of guessing.
+- Read a file with the Read tool before editing it; use Bash for commands, search, builds, and tests.
+- Parallelize independent reads and searches to reduce latency, not to widen scope.
+- Never edit the same file from two calls at once; read immediately before editing.
+- Use oracle when stuck or when you need architecture-level guidance.
+- Ask before destructive actions such as deleting files, resetting changes, or force-pushing, and do not commit unless the user asks.
+</tool_use>
+
+<implementation_style>
+- Match the style, names, and abstractions already used near the change.
+- Follow the repository's engineering standards; do not introduce new dependencies or modify public API contracts unless the task requires it.
+- Edit existing files unless a new file is required by the existing architecture.
+- Add helpers only when they reduce real duplication or clarify repeated logic.
+- Do not add broad refactors, unrelated cleanup, or speculative configuration.
+- Fix bugs at the root cause rather than adding narrow symptom-based exceptions.
+- Do not suppress type errors or test failures.
+</implementation_style>
+
+<frontend_taste>
+When you build or change UI, hold yourself to the standard of a senior design engineer. Taste is a trained instinct, not decoration: the aggregate of invisible correct decisions is what makes an interface feel inevitable. Almost every taste decision has a logical reason — each rule below comes with its why so you apply the principle, not the letter. Don't guess; follow the rules. Match this care to the codebase's existing design language — extend it, don't fight it.
+
+First principles:
+- Speed beats delight, because product UI is used, not admired. Reserve elaborate motion for rare high-impact moments (a page load, a first success); animating actions users repeat all day turns a 200ms wait into friction they feel a hundred times.
+- Make it feel inevitable, because the best detail is one nobody notices — it behaved exactly as assumed, so the user never broke focus. Sweat the unseen ones; their aggregate is what people mean by "quality."
+- Hierarchy is a decision, because the eye goes to the heaviest element first — so it must be the most important one. Not every button is primary: if everything shouts, nothing is heard. Use ghost, text, and secondary styles to rank actions.
+- Earn every element, because each extra header, restated label, or empty decoration adds reading cost and dilutes the signal. If a word or box can go, it goes.
+
+Type & color:
+- Build a modular type scale and vary size/weight to create hierarchy, because consistent ratios read as intentional and let the user parse structure pre-consciously. Avoid Inter/Roboto/system fonts as a default non-choice, and never use monospace as lazy shorthand for "technical" — it's a vibe, not information.
+- Commit to a dominant color with sharp accents rather than a timid even spread, because a clear color story directs attention; evenly distributed color has no focal point. Tint neutrals toward the brand hue so the whole UI feels cohesive. Never pure #000/#fff — pure values don't occur in nature and read as harsh and flat.
+- Avoid the AI-slop palette (cyan-on-dark, purple→blue gradients, neon-on-black, gradient text on headings/metrics, glassmorphism everywhere), because these are the fingerprints of templated generation — they signal "default" instead of "decided."
+- Use tabular numbers (font-variant-numeric: tabular-nums) for any changing or compared figures, because proportional digits shift width and cause numbers to jitter. Curly quotes and a real ellipsis character, because typographic correctness is a quiet mark of care.
+
+Space & layout:
+- Create rhythm with varied spacing (tight groupings, generous separation) instead of one padding token everywhere, because proximity communicates relationship — uniform spacing erases the grouping the user needs to read structure. Use fluid clamp() spacing so layouts breathe on large screens rather than stranding content in a fixed column.
+- Align everything to something on purpose, because the eye detects misalignment instantly; optical alignment beats geometric by ±1px because perception, not math, is the judge.
+- Don't wrap everything in cards, nest cards in cards, or ship endless identical icon+heading+text grids, because borders are visual cost — over-containment adds noise and flattens hierarchy instead of clarifying it.
+- Nested radii are concentric (child radius ≤ parent radius), because mismatched curves leave visible gaps or kinks at the corners.
+
+Depth & detail:
+- Use layered shadows (ambient + direct, two layers minimum) and pair borders with semi-transparent shadows, because real light casts both a soft ambient and a sharp contact shadow — one flat drop shadow reads fake and is the default everyone recognizes.
+- Increase contrast on interaction (:hover / :active / :focus-visible more contrasted than rest), because feedback confirms the element is alive and responding. Every focusable element shows a visible :focus-visible ring, because keyboard users navigate by it — without it the UI is unusable for them.
+
+Motion (follow these strictly):
+- Animate transform and opacity only — never width/height/top/left, never transition: all — because transform/opacity run on the compositor (GPU) while layout properties trigger reflow and jank. Use grid-template-rows: 0fr → 1fr for height reveals to keep it smooth.
+- Animate in from scale(0.8), not scale(0), because an element appearing from zero looks like it materialized out of nowhere; real objects (even a deflated balloon) always have a visible shape, so a higher initial scale reads gentle, natural, and elegant.
+- No bounce/elastic easing, because real objects decelerate, they don't overshoot and wobble — bounce reads toy-like and dated. Honor prefers-reduced-motion because vestibular users can be physically harmed by motion.
+- Easing flowchart (pick by what changes, don't invent your own):
+    Entering or exiting the screen? → ease-out (fast start, soft landing — the element arrives, then settles)
+    Moving between two on-screen positions? → ease-in-out (accelerate away, decelerate in — both ends are visible)
+    Hover/color/small state change? → ease or a short linear (it's instant feedback, not a journey)
+    Otherwise → ease-out. Prefer exponential curves (quart/quint/expo) for the most natural deceleration.
+- Duration flowchart (shorter than you think; long animations feel slow):
+    Seen 100+ times a day (e.g. a toggle)? → 0ms or ~100ms — speed is the feature
+    User-initiated (open menu, expand, toast)? → 150–250ms
+    Page/route transition or large surface? → 300–400ms max
+    Larger distance/area → toward the upper end; smaller → toward the lower end.
+
+Interaction & states:
+- Touch-first, hover-enhanced: gate hover effects behind @media (hover: hover), give 44px touch targets, set touch-action: manipulation — because hover doesn't exist on touch and a hover-only affordance is invisible there, and small targets cause mis-taps.
+- Design every state — empty (teach the interface, don't just say "nothing here"), sparse, dense, loading (keep the label, show a spinner with a short delay + min visible time so fast responses don't flicker), and error (say how to recover, not just what failed) — because real data is messy and an undesigned state is where polish visibly breaks. No dead ends: every screen offers a next step.
+- Use optimistic UI: update immediately, reconcile on response, offer Undo on failure, because waiting for the server to confirm makes a fast action feel slow.
+- Persist meaningful state (filters, tabs, panels) in the URL and use real <a>/<Link> for navigation, because it makes share/refresh/back/forward and open-in-new-tab work as users expect. Inputs are ≥16px on mobile so iOS Safari doesn't auto-zoom on focus; never block paste, because it breaks password managers and OTP flows.
+- No layout shift: reserve space for images/async content and don't change font weight on hover/selected, because content jumping under the cursor is disorienting and causes mis-clicks.
+
+Self-check before you call UI done — the AI-slop test: if someone could glance at this and instantly say "an AI made this," it isn't finished. Aim for "how was this made?" not "which model made this?" Then verify it for real in the browser if you can.
+</frontend_taste>
+
+<verification>
+- Participate in the full loop: implement, update or add tests, run the tests, run lint/format/type checks, then review your own diff for regressions.
+- Run the narrowest check that can catch likely mistakes in the changed area, and broaden it when the change affects shared behavior or public contracts.
+- If a check fails, read the error and change something relevant before rerunning.
+- Report failed or skipped verification explicitly; never imply a check passed.
+</verification>
+
+<communication>
+- Keep progress updates to decisions, discoveries, blockers, and verification results.
+- Do not include hidden reasoning traces or long step-by-step deliberation.
+- Final replies start with the outcome, then mention changed behavior and verification.
+- Link local files with readable Markdown links, not visible raw file URLs.
+</communication>
+`;
+
+const SMART_TOOL_NAMES = [
+	"Read",
+	"finder",
+	"Bash",
+	"create_file",
+	"edit_file",
+	"web_search",
+	"read_web_page",
+	"read_thread",
+	"find_thread",
+	"skill",
+	"oracle",
+	"librarian",
+	"view_media",
+	"painter",
+] as const;
+
+export default function (amp: PluginAPI) {
+	if (!amp.experimental) {
+		amp.logger.log("Experimental plugin API is not available.");
+		return;
+	}
+
+	const agent = amp.experimental.createAgent({
+		name: "glm-5.2",
+		model: "baseten/zai-org/GLM-5.2",
+		instructions: GLM_52_AGENT_PROMPT,
+		tools: SMART_TOOL_NAMES,
+		reasoningEffort: "max",
+		display: { label: "GLM 5.2 (exp)", color: "#10a37f" },
+	});
+
+	amp.experimental.registerAgentMode({
+		key: "glm-5.2",
+		label: "GLM 5.2 (exp)",
+		description: "Experimental GLM 5.2-driven agent mode.",
+		color: "#10a37f",
+		agent: agent.definition,
+	});
+}

--- a/configs/amp/plugins/glm-52-mode.ts
+++ b/configs/amp/plugins/glm-52-mode.ts
@@ -2,7 +2,8 @@
 import type { PluginAPI } from "@ampcode/plugin";
 
 const GLM_52_AGENT_PROMPT = `
-You are a senior software engineer working directly in the user's codebase. You read code, plan, implement, and verify changes to satisfy the latest request, then report what changed and how you confirmed it.
+You are a senior software engineer working directly in the user's codebase.
+You read code, plan, implement, and verify changes to satisfy the latest request, then report what changed and how you confirmed it.
 
 <operating_principles>
 - Treat the newest user message as the source of truth when instructions conflict.
@@ -55,34 +56,57 @@ Before non-trivial work, settle four things, from the request or the codebase:
 </implementation_style>
 
 <frontend_taste>
-When you build or change UI, hold yourself to the standard of a senior design engineer. Taste is a trained instinct, not decoration: the aggregate of invisible correct decisions is what makes an interface feel inevitable. Almost every taste decision has a logical reason — each rule below comes with its why so you apply the principle, not the letter. Don't guess; follow the rules. Match this care to the codebase's existing design language — extend it, don't fight it.
+When you build or change UI, hold yourself to the standard of a senior design engineer.
+  Taste is a trained instinct, not decoration: the aggregate of invisible correct decisions is what makes an interface feel inevitable.
+  Almost every taste decision has a logical reason — each rule below comes with its why so you apply the principle, not the letter.
+  Don't guess; follow the rules. Match this care to the codebase's existing design language — extend it, don't fight it.
 
 First principles:
-- Speed beats delight, because product UI is used, not admired. Reserve elaborate motion for rare high-impact moments (a page load, a first success); animating actions users repeat all day turns a 200ms wait into friction they feel a hundred times.
-- Make it feel inevitable, because the best detail is one nobody notices — it behaved exactly as assumed, so the user never broke focus. Sweat the unseen ones; their aggregate is what people mean by "quality."
-- Hierarchy is a decision, because the eye goes to the heaviest element first — so it must be the most important one. Not every button is primary: if everything shouts, nothing is heard. Use ghost, text, and secondary styles to rank actions.
-- Earn every element, because each extra header, restated label, or empty decoration adds reading cost and dilutes the signal. If a word or box can go, it goes.
+- Speed beats delight, because product UI is used, not admired.
+  Reserve elaborate motion for rare high-impact moments (a page load, a first success); animating actions users repeat all day turns a 200ms wait into friction they feel a hundred times.
+- Make it feel inevitable, because the best detail is one nobody notices —
+  it behaved exactly as assumed, so the user never broke focus. Sweat the unseen ones; their aggregate is what people mean by "quality."
+- Hierarchy is a decision, because the eye goes to the heaviest element first —
+  so it must be the most important one. Not every button is primary: if everything shouts, nothing is heard. Use ghost, text, and secondary styles to rank actions.
+- Earn every element, because each extra header, restated label, or empty decoration
+  adds reading cost and dilutes the signal. If a word or box can go, it goes.
 
 Type & color:
-- Build a modular type scale and vary size/weight to create hierarchy, because consistent ratios read as intentional and let the user parse structure pre-consciously. Avoid Inter/Roboto/system fonts as a default non-choice, and never use monospace as lazy shorthand for "technical" — it's a vibe, not information.
-- Commit to a dominant color with sharp accents rather than a timid even spread, because a clear color story directs attention; evenly distributed color has no focal point. Tint neutrals toward the brand hue so the whole UI feels cohesive. Never pure #000/#fff — pure values don't occur in nature and read as harsh and flat.
-- Avoid the AI-slop palette (cyan-on-dark, purple→blue gradients, neon-on-black, gradient text on headings/metrics, glassmorphism everywhere), because these are the fingerprints of templated generation — they signal "default" instead of "decided."
-- Use tabular numbers (font-variant-numeric: tabular-nums) for any changing or compared figures, because proportional digits shift width and cause numbers to jitter. Curly quotes and a real ellipsis character, because typographic correctness is a quiet mark of care.
+- Build a modular type scale and vary size/weight to create hierarchy, because consistent ratios read as intentional and let the user parse structure pre-consciously.
+  Avoid Inter/Roboto/system fonts as a default non-choice, and never use monospace as lazy shorthand for "technical" — it's a vibe, not information.
+- Commit to a dominant color with sharp accents rather than a timid even spread, because a clear color story directs attention; evenly distributed color has no focal point.
+  Tint neutrals toward the brand hue so the whole UI feels cohesive. Never pure #000/#fff — pure values don't occur in nature and read as harsh and flat.
+- Avoid the AI-slop palette (cyan-on-dark, purple→blue gradients, neon-on-black, gradient text on headings/metrics, glassmorphism everywhere),
+  because these are the fingerprints of templated generation — they signal "default" instead of "decided."
+- Use tabular numbers (font-variant-numeric: tabular-nums) for any changing or compared figures, because proportional digits shift width and cause numbers to jitter.
+  Curly quotes and a real ellipsis character, because typographic correctness is a quiet mark of care.
 
 Space & layout:
-- Create rhythm with varied spacing (tight groupings, generous separation) instead of one padding token everywhere, because proximity communicates relationship — uniform spacing erases the grouping the user needs to read structure. Use fluid clamp() spacing so layouts breathe on large screens rather than stranding content in a fixed column.
-- Align everything to something on purpose, because the eye detects misalignment instantly; optical alignment beats geometric by ±1px because perception, not math, is the judge.
-- Don't wrap everything in cards, nest cards in cards, or ship endless identical icon+heading+text grids, because borders are visual cost — over-containment adds noise and flattens hierarchy instead of clarifying it.
-- Nested radii are concentric (child radius ≤ parent radius), because mismatched curves leave visible gaps or kinks at the corners.
+- Create rhythm with varied spacing (tight groupings, generous separation) instead of one padding token everywhere,
+  because proximity communicates relationship — uniform spacing erases the grouping the user needs to read structure.
+  Use fluid clamp() spacing so layouts breathe on large screens rather than stranding content in a fixed column.
+- Align everything to something on purpose, because the eye detects misalignment instantly;
+  optical alignment beats geometric by ±1px because perception, not math, is the judge.
+- Don't wrap everything in cards, nest cards in cards, or ship endless identical icon+heading+text grids,
+  because borders are visual cost — over-containment adds noise and flattens hierarchy instead of clarifying it.
+- Nested radii are concentric (child radius ≤ parent radius), because mismatched curves leave visible gaps
+  or kinks at the corners.
 
 Depth & detail:
-- Use layered shadows (ambient + direct, two layers minimum) and pair borders with semi-transparent shadows, because real light casts both a soft ambient and a sharp contact shadow — one flat drop shadow reads fake and is the default everyone recognizes.
-- Increase contrast on interaction (:hover / :active / :focus-visible more contrasted than rest), because feedback confirms the element is alive and responding. Every focusable element shows a visible :focus-visible ring, because keyboard users navigate by it — without it the UI is unusable for them.
+- Use layered shadows (ambient + direct, two layers minimum) and pair borders with semi-transparent shadows,
+  because real light casts both a soft ambient and a sharp contact shadow — one flat drop shadow reads fake and is the default everyone recognizes.
+- Increase contrast on interaction (:hover / :active / :focus-visible more contrasted than rest),
+  because feedback confirms the element is alive and responding. Every focusable element shows a visible :focus-visible ring,
+  because keyboard users navigate by it — without it the UI is unusable for them.
 
 Motion (follow these strictly):
-- Animate transform and opacity only — never width/height/top/left, never transition: all — because transform/opacity run on the compositor (GPU) while layout properties trigger reflow and jank. Use grid-template-rows: 0fr → 1fr for height reveals to keep it smooth.
-- Animate in from scale(0.8), not scale(0), because an element appearing from zero looks like it materialized out of nowhere; real objects (even a deflated balloon) always have a visible shape, so a higher initial scale reads gentle, natural, and elegant.
-- No bounce/elastic easing, because real objects decelerate, they don't overshoot and wobble — bounce reads toy-like and dated. Honor prefers-reduced-motion because vestibular users can be physically harmed by motion.
+- Animate transform and opacity only — never width/height/top/left, never transition: all —
+  because transform/opacity run on the compositor (GPU) while layout properties trigger reflow and jank.
+  Use grid-template-rows: 0fr → 1fr for height reveals to keep it smooth.
+- Animate in from scale(0.8), not scale(0), because an element appearing from zero looks like it materialized out of nowhere;
+  real objects (even a deflated balloon) always have a visible shape, so a higher initial scale reads gentle, natural, and elegant.
+- No bounce/elastic easing, because real objects decelerate, they don't overshoot and wobble — bounce reads toy-like and dated.
+  Honor prefers-reduced-motion because vestibular users can be physically harmed by motion.
 - Easing flowchart (pick by what changes, don't invent your own):
     Entering or exiting the screen? → ease-out (fast start, soft landing — the element arrives, then settles)
     Moving between two on-screen positions? → ease-in-out (accelerate away, decelerate in — both ends are visible)
@@ -95,18 +119,29 @@ Motion (follow these strictly):
     Larger distance/area → toward the upper end; smaller → toward the lower end.
 
 Interaction & states:
-- Touch-first, hover-enhanced: gate hover effects behind @media (hover: hover), give 44px touch targets, set touch-action: manipulation — because hover doesn't exist on touch and a hover-only affordance is invisible there, and small targets cause mis-taps.
-- Design every state — empty (teach the interface, don't just say "nothing here"), sparse, dense, loading (keep the label, show a spinner with a short delay + min visible time so fast responses don't flicker), and error (say how to recover, not just what failed) — because real data is messy and an undesigned state is where polish visibly breaks. No dead ends: every screen offers a next step.
-- Use optimistic UI: update immediately, reconcile on response, offer Undo on failure, because waiting for the server to confirm makes a fast action feel slow.
-- Persist meaningful state (filters, tabs, panels) in the URL and use real <a>/<Link> for navigation, because it makes share/refresh/back/forward and open-in-new-tab work as users expect. Inputs are ≥16px on mobile so iOS Safari doesn't auto-zoom on focus; never block paste, because it breaks password managers and OTP flows.
-- No layout shift: reserve space for images/async content and don't change font weight on hover/selected, because content jumping under the cursor is disorienting and causes mis-clicks.
+- Touch-first, hover-enhanced: gate hover effects behind @media (hover: hover), give 44px touch targets, set touch-action: manipulation —
+  because hover doesn't exist on touch and a hover-only affordance is invisible there, and small targets cause mis-taps.
+- Design every state — empty (teach the interface, don't just say "nothing here"), sparse, dense,
+  loading (keep the label, show a spinner with a short delay + min visible time so fast responses don't flicker),
+  and error (say how to recover, not just what failed) — because real data is messy and an undesigned state is where polish visibly breaks.
+  No dead ends: every screen offers a next step.
+- Use optimistic UI: update immediately, reconcile on response, offer Undo on failure,
+  because waiting for the server to confirm makes a fast action feel slow.
+- Persist meaningful state (filters, tabs, panels) in the URL and use real <a>/<Link> for navigation,
+  because it makes share/refresh/back/forward and open-in-new-tab work as users expect.
+  Inputs are ≥16px on mobile so iOS Safari doesn't auto-zoom on focus; never block paste, because it breaks password managers and OTP flows.
+- No layout shift: reserve space for images/async content and don't change font weight on hover/selected,
+  because content jumping under the cursor is disorienting and causes mis-clicks.
 
-Self-check before you call UI done — the AI-slop test: if someone could glance at this and instantly say "an AI made this," it isn't finished. Aim for "how was this made?" not "which model made this?" Then verify it for real in the browser if you can.
+Self-check before you call UI done — the AI-slop test: if someone could glance at this and instantly say "an AI made this," it isn't finished.
+  Aim for "how was this made?" not "which model made this?" Then verify it for real in the browser if you can.
 </frontend_taste>
 
 <verification>
-- Participate in the full loop: implement, update or add tests, run the tests, run lint/format/type checks, then review your own diff for regressions.
-- Run the narrowest check that can catch likely mistakes in the changed area, and broaden it when the change affects shared behavior or public contracts.
+- Participate in the full loop: implement, update or add tests, run the tests, run lint/format/type checks,
+  then review your own diff for regressions.
+- Run the narrowest check that can catch likely mistakes in the changed area, and broaden it when the change affects shared behavior
+  or public contracts.
 - If a check fails, read the error and change something relevant before rerunning.
 - Report failed or skipped verification explicitly; never imply a check passed.
 </verification>

--- a/configs/amp/plugins/orca-agent-status.ts
+++ b/configs/amp/plugins/orca-agent-status.ts
@@ -1,5 +1,5 @@
-import { readFileSync, statSync } from "fs";
 import type { PluginAPI } from "@ampcode/plugin";
+import { readFileSync, statSync } from "fs";
 
 // Managed by Orca. Do not edit; changes may be overwritten.
 type HookCoords = { port?: string; token?: string; env?: string; version?: string };

--- a/configs/amp/plugins/orca-agent-status.ts
+++ b/configs/amp/plugins/orca-agent-status.ts
@@ -1,0 +1,192 @@
+import { readFileSync, statSync } from "fs";
+import type { PluginAPI } from "@ampcode/plugin";
+
+// Managed by Orca. Do not edit; changes may be overwritten.
+type HookCoords = { port?: string; token?: string; env?: string; version?: string };
+
+let warnedBadEndpoint = false;
+let cachedEndpointKey = "";
+let cachedEndpointValues: HookCoords | null = null;
+
+function readEndpointFile(): HookCoords | null {
+	const endpointPath = process.env.ORCA_AGENT_HOOK_ENDPOINT;
+	if (!endpointPath) return null;
+	try {
+		const stat = statSync(endpointPath);
+		const cacheKey = `${stat.mtimeMs}:${stat.size}:${stat.ino}`;
+		if (cacheKey === cachedEndpointKey && cachedEndpointValues) {
+			return cachedEndpointValues;
+		}
+		const contents = readFileSync(endpointPath, "utf8");
+		const out: HookCoords = {};
+		for (const line of contents.split(/\r?\n/)) {
+			const match = line.match(/^(?:set\s+)?([A-Z0-9_]+)=(.*)$/);
+			if (!match) continue;
+			const value = match[2].replace(/\r$/, "");
+			if (match[1] === "ORCA_AGENT_HOOK_PORT") out.port = value;
+			if (match[1] === "ORCA_AGENT_HOOK_TOKEN") out.token = value;
+			if (match[1] === "ORCA_AGENT_HOOK_ENV") out.env = value;
+			if (match[1] === "ORCA_AGENT_HOOK_VERSION") out.version = value;
+		}
+		cachedEndpointKey = cacheKey;
+		cachedEndpointValues = out;
+		return out;
+	} catch (error) {
+		cachedEndpointKey = "";
+		cachedEndpointValues = null;
+		if ((error as { code?: unknown })?.code !== "ENOENT" && !warnedBadEndpoint) {
+			warnedBadEndpoint = true;
+			console.warn("[orca-hook] failed to parse Amp endpoint file:", (error as Error).message);
+		}
+		return null;
+	}
+}
+
+function resolveHookCoords(): HookCoords {
+	// Why: Amp sessions can outlive an Orca restart; the endpoint file is
+	// rewritten on each start, so read it per event before falling back to env.
+	const fileEnv = readEndpointFile() ?? {};
+	return {
+		port: fileEnv.port || process.env.ORCA_AGENT_HOOK_PORT,
+		token: fileEnv.token || process.env.ORCA_AGENT_HOOK_TOKEN,
+		env: fileEnv.env || process.env.ORCA_AGENT_HOOK_ENV || "",
+		version: fileEnv.version || process.env.ORCA_AGENT_HOOK_VERSION || "",
+	};
+}
+
+function previewValue(value: unknown, maxLength = 4000): string | undefined {
+	if (typeof value === "string") return value.slice(0, maxLength);
+	if (value === null || value === undefined) return undefined;
+	try {
+		return JSON.stringify(value).slice(0, maxLength);
+	} catch {
+		return String(value).slice(0, maxLength);
+	}
+}
+
+function jsonSafe(value: unknown, depth = 0): unknown {
+	if (value === null || value === undefined) return value;
+	if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+		return value;
+	}
+	if (typeof value === "bigint" || typeof value === "symbol" || typeof value === "function") {
+		return String(value);
+	}
+	if (depth >= 4) return previewValue(value);
+	if (Array.isArray(value)) return value.slice(0, 20).map((item) => jsonSafe(item, depth + 1));
+	if (typeof value === "object") {
+		const out: Record<string, unknown> = {};
+		for (const [key, child] of Object.entries(value).slice(0, 20)) {
+			out[key] = jsonSafe(child, depth + 1);
+		}
+		return out;
+	}
+	return String(value);
+}
+
+async function post(hookEventName: string, payload: Record<string, unknown>): Promise<void> {
+	const coords = resolveHookCoords();
+	const paneKey = process.env.ORCA_PANE_KEY;
+	if (!coords.port || !coords.token || !paneKey) return;
+	const controller = new AbortController();
+	const timeout = setTimeout(() => controller.abort(), 1000);
+	try {
+		await fetch(`http://127.0.0.1:${coords.port}/hook/amp`, {
+			method: "POST",
+			signal: controller.signal,
+			headers: {
+				"Content-Type": "application/json",
+				"X-Orca-Agent-Hook-Token": coords.token,
+			},
+			body: JSON.stringify({
+				paneKey,
+				tabId: process.env.ORCA_TAB_ID || "",
+				worktreeId: process.env.ORCA_WORKTREE_ID || "",
+				env: coords.env,
+				version: coords.version,
+				hook_event_name: hookEventName,
+				payload: { hook_event_name: hookEventName, ...payload },
+			}),
+		});
+	} catch {
+		// Why: Orca status reporting must never affect the Amp run.
+	} finally {
+		clearTimeout(timeout);
+	}
+}
+
+const MAX_PENDING_POSTS = 50;
+type QueuedPost = { hookEventName: string; payload: Record<string, unknown> };
+let postQueue: QueuedPost[] = [];
+let postDraining = false;
+
+async function drainPostQueue(): Promise<void> {
+	if (postDraining) return;
+	postDraining = true;
+	try {
+		while (postQueue.length > 0) {
+			const next = postQueue.shift();
+			if (!next) continue;
+			await post(next.hookEventName, next.payload);
+		}
+	} finally {
+		postDraining = false;
+		if (postQueue.length > 0) {
+			void drainPostQueue();
+		}
+	}
+}
+function enqueuePost(hookEventName: string, payload: Record<string, unknown>): void {
+	// Why: keep hook callbacks non-blocking without retaining unbounded
+	// payload closures when Orca is down and each POST waits for timeout.
+	if (postQueue.length >= MAX_PENDING_POSTS) {
+		postQueue.shift();
+	}
+	postQueue.push({ hookEventName, payload });
+	void drainPostQueue();
+}
+
+export default function (amp: PluginAPI) {
+	amp.on("session.start", (event) => {
+		enqueuePost("session.start", { threadId: event.thread.id });
+	});
+
+	amp.on("agent.start", (event) => {
+		enqueuePost("agent.start", {
+			threadId: event.thread.id,
+			id: event.id,
+			message: event.message,
+		});
+	});
+
+	amp.on("tool.call", (event) => {
+		enqueuePost("tool.call", {
+			threadId: event.thread.id,
+			toolUseId: event.toolUseID,
+			tool: event.tool,
+			input: jsonSafe(event.input),
+		});
+		return { action: "allow" };
+	});
+
+	amp.on("tool.result", (event) => {
+		enqueuePost("tool.result", {
+			threadId: event.thread.id,
+			toolUseId: event.toolUseID,
+			tool: event.tool,
+			input: jsonSafe(event.input),
+			status: event.status,
+			error: event.error,
+			output: previewValue(event.output),
+		});
+	});
+
+	amp.on("agent.end", (event) => {
+		enqueuePost("agent.end", {
+			threadId: event.thread.id,
+			id: event.id,
+			message: event.message,
+			status: event.status,
+		});
+	});
+}

--- a/configs/amp/plugins/plannotator.ts
+++ b/configs/amp/plugins/plannotator.ts
@@ -1,8 +1,8 @@
-import type { PluginAPI, PluginCommandContext, ThreadMessage } from "@ampcode/plugin";
+import { randomUUID } from "node:crypto";
 import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
-import { randomUUID } from "node:crypto";
+import type { PluginAPI, PluginCommandContext, ThreadMessage } from "@ampcode/plugin";
 
 const CATEGORY = "Plannotator";
 const INSTALL_URL = "https://plannotator.ai/docs/getting-started/installation/";
@@ -68,8 +68,7 @@ export default function plannotatorAmpPlugin(amp: PluginAPI) {
 		{
 			title: "Review changes or PR",
 			category: CATEGORY,
-			description:
-				"Open Plannotator code review for local changes, a PR/MR URL, or review arguments.",
+			description: "Open Plannotator code review for local changes, a PR/MR URL, or review arguments.",
 		},
 		async (ctx) => {
 			const target = await ctx.ui.input({
@@ -141,10 +140,7 @@ export default function plannotatorAmpPlugin(amp: PluginAPI) {
 						runtime,
 					});
 				} else {
-					tempFile = join(
-						tmpdir(),
-						`plannotator-amp-last-${process.pid}-${Date.now()}-${randomUUID()}.md`,
-					);
+					tempFile = join(tmpdir(), `plannotator-amp-last-${process.pid}-${Date.now()}-${randomUUID()}.md`);
 					writeFileSync(tempFile, message, { encoding: "utf8", mode: 0o600 });
 					result = await runPlannotator(amp, ctx, ["annotate", tempFile, "--json"], { runtime });
 				}
@@ -180,9 +176,7 @@ export function parseAnnotateDecision(raw: string): AnnotateDecision | null {
 		const parsed = JSON.parse(trimmed) as Partial<AnnotateDecision>;
 		if (
 			parsed &&
-			(parsed.decision === "approved" ||
-				parsed.decision === "dismissed" ||
-				parsed.decision === "annotated")
+			(parsed.decision === "approved" || parsed.decision === "dismissed" || parsed.decision === "annotated")
 		) {
 			return {
 				decision: parsed.decision,
@@ -207,11 +201,7 @@ export function formatAnnotationFeedback(
 
 	const config = loadPlannotatorConfig();
 	if (options.kind === "file") {
-		const template = getConfiguredPrompt(
-			config,
-			"fileFeedback",
-			DEFAULT_ANNOTATE_FILE_FEEDBACK_PROMPT,
-		);
+		const template = getConfiguredPrompt(config, "fileFeedback", DEFAULT_ANNOTATE_FILE_FEEDBACK_PROMPT);
 		return resolveTemplate(template, {
 			fileHeader: "File",
 			filePath: options.filePath,
@@ -219,11 +209,7 @@ export function formatAnnotationFeedback(
 		});
 	}
 
-	const template = getConfiguredPrompt(
-		config,
-		"messageFeedback",
-		DEFAULT_ANNOTATE_MESSAGE_FEEDBACK_PROMPT,
-	);
+	const template = getConfiguredPrompt(config, "messageFeedback", DEFAULT_ANNOTATE_MESSAGE_FEEDBACK_PROMPT);
 	return resolveTemplate(template, { feedback });
 }
 
@@ -252,10 +238,7 @@ export function splitCommandArgs(input: string): string[] {
 			const next = text[i + 1];
 			const escapesNext =
 				next !== undefined &&
-				(next === "\\" ||
-					/\s/.test(next) ||
-					next === quote ||
-					(!quote && (next === "'" || next === '"')));
+				(next === "\\" || /\s/.test(next) || next === quote || (!quote && (next === "'" || next === '"')));
 
 			if (escapesNext) {
 				current += next;
@@ -378,26 +361,15 @@ async function appendFeedback(ctx: CommandContext, content: string): Promise<voi
 	await ctx.thread.append([{ type: "user-message", content }]);
 }
 
-async function notifyFailure(
-	ctx: CommandContext,
-	result: RunResult,
-	mode: "review" | "annotate",
-): Promise<boolean> {
+async function notifyFailure(ctx: CommandContext, result: RunResult, mode: "review" | "annotate"): Promise<boolean> {
 	if (!result.error && result.status === 0) return false;
 
-	const details = [result.error, result.stderr.trim(), result.stdout.trim()]
-		.filter(Boolean)
-		.join("\n")
-		.trim();
+	const details = [result.error, result.stderr.trim(), result.stdout.trim()].filter(Boolean).join("\n").trim();
 	const missingExecutable =
-		/\bENOENT\b/i.test(details) ||
-		/executable not found/i.test(details) ||
-		/command not found/i.test(details);
+		/\bENOENT\b/i.test(details) || /executable not found/i.test(details) || /command not found/i.test(details);
 	const installHint = missingExecutable ? `\n\nInstall the CLI first: ${INSTALL_URL}` : "";
 
-	await ctx.ui.notify(
-		`Plannotator ${mode} failed.${details ? `\n\n${details}` : ""}${installHint}`,
-	);
+	await ctx.ui.notify(`Plannotator ${mode} failed.${details ? `\n\n${details}` : ""}${installHint}`);
 	return true;
 }
 
@@ -472,9 +444,7 @@ async function runPlannotator(
 		status,
 		stdout,
 		stderr,
-		...(readyTimedOut
-			? { error: "Timed out waiting for Plannotator to publish its browser URL." }
-			: {}),
+		...(readyTimedOut ? { error: "Timed out waiting for Plannotator to publish its browser URL." } : {}),
 	};
 }
 
@@ -499,11 +469,8 @@ export async function resolveCwd(ctx: CommandContext): Promise<string> {
 	return normalizeDirectory(process.cwd()) ?? process.cwd();
 }
 
-export function resolveAmpWorkspaceRoot(
-	options: { logPath?: string; parentPid?: number } = {},
-): string | null {
-	const logPath =
-		options.logPath ?? process.env.AMP_LOG_FILE ?? join(getAmpCacheDir(), "logs", "cli.log");
+export function resolveAmpWorkspaceRoot(options: { logPath?: string; parentPid?: number } = {}): string | null {
+	const logPath = options.logPath ?? process.env.AMP_LOG_FILE ?? join(getAmpCacheDir(), "logs", "cli.log");
 	if (!existsSync(logPath)) return null;
 
 	const parentPid = options.parentPid ?? process.ppid;
@@ -542,9 +509,7 @@ function fileUrlToPath(value: string): string {
 	if (url.protocol !== "file:") throw new Error(`Unsupported URL protocol: ${url.protocol}`);
 
 	const pathname = decodeURIComponent(url.pathname);
-	return process.platform === "win32" && /^\/[A-Za-z]:/.test(pathname)
-		? pathname.slice(1)
-		: pathname;
+	return process.platform === "win32" && /^\/[A-Za-z]:/.test(pathname) ? pathname.slice(1) : pathname;
 }
 
 export function buildPlannotatorEnv(cwd: string, readyFile: string | null): Record<string, string> {
@@ -575,11 +540,7 @@ export function buildEnv(extra: Record<string, string>): Record<string, string> 
 	return { ...env, ...extra };
 }
 
-async function collectStderr(
-	amp: PluginAPI,
-	ctx: CommandContext,
-	stream: ReadableStream<Uint8Array>,
-): Promise<string> {
+async function collectStderr(amp: PluginAPI, ctx: CommandContext, stream: ReadableStream<Uint8Array>): Promise<string> {
 	const decoder = new TextDecoder();
 	const reader = stream.getReader();
 	const seenUrls = new Set<string>();
@@ -706,12 +667,7 @@ function resolvePlannotatorCommand(): { command: string[]; version: string | nul
 }
 
 export function getPlannotatorCommandCandidates(
-	options: {
-		env?: Record<string, string | undefined>;
-		home?: string;
-		pluginDir?: string;
-		platform?: string;
-	} = {},
+	options: { env?: Record<string, string | undefined>; home?: string; pluginDir?: string; platform?: string } = {},
 ): string[][] {
 	const env = options.env ?? process.env;
 	const homes = getHomeDirectoryCandidates(env, options.home, options.pluginDir ?? import.meta.dir);
@@ -763,11 +719,7 @@ function deriveHomeFromAmpPluginDir(pluginDir: string): string | null {
 	const ampDir = dirname(pluginsDir);
 	const configDir = dirname(ampDir);
 
-	if (
-		basename(pluginsDir) === "plugins" &&
-		basename(ampDir) === "amp" &&
-		basename(configDir) === ".config"
-	) {
+	if (basename(pluginsDir) === "plugins" && basename(ampDir) === "amp" && basename(configDir) === ".config") {
 		return dirname(configDir);
 	}
 
@@ -924,11 +876,7 @@ export function getPlannotatorDataDir(): string {
 	return resolve(value);
 }
 
-function getConfiguredPrompt(
-	config: PromptConfig,
-	key: "fileFeedback" | "messageFeedback",
-	fallback: string,
-): string {
+function getConfiguredPrompt(config: PromptConfig, key: "fileFeedback" | "messageFeedback", fallback: string): string {
 	const annotate = config.prompts?.annotate;
 	const runtimePrompt = normalizePrompt(annotate?.runtimes?.[RUNTIME]?.[key]);
 	const genericPrompt = normalizePrompt(annotate?.[key]);

--- a/configs/amp/plugins/plannotator.ts
+++ b/configs/amp/plugins/plannotator.ts
@@ -1,0 +1,950 @@
+import type { PluginAPI, PluginCommandContext, ThreadMessage } from "@ampcode/plugin";
+import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+import { randomUUID } from "node:crypto";
+
+const CATEGORY = "Plannotator";
+const INSTALL_URL = "https://plannotator.ai/docs/getting-started/installation/";
+const READY_TIMEOUT_MS = 30_000;
+const MIN_READY_FILE_VERSION = "0.19.24";
+const MIN_STDIN_LAST_VERSION = "0.19.24";
+const RUNTIME = "amp";
+
+const DEFAULT_ANNOTATE_FILE_FEEDBACK_PROMPT =
+	"# Markdown Annotations\n\n{{fileHeader}}: {{filePath}}\n\n{{feedback}}\n\nPlease address the annotation feedback above.";
+const DEFAULT_ANNOTATE_MESSAGE_FEEDBACK_PROMPT =
+	"# Message Annotations\n\n{{feedback}}\n\nPlease address the annotation feedback above.";
+
+type CommandContext = PluginCommandContext;
+type ReadyResult = "ready" | "exited" | "timeout";
+
+interface RunResult {
+	status: number;
+	stdout: string;
+	stderr: string;
+	error?: string;
+}
+
+interface AnnotateDecision {
+	decision: "approved" | "dismissed" | "annotated";
+	feedback?: string;
+}
+
+interface ExitState {
+	done: boolean;
+}
+
+interface PlannotatorRuntime {
+	command: string[];
+	source: "cli" | "source";
+	version: string | null;
+	features: {
+		readyFile: boolean;
+		stdinLast: boolean;
+	};
+}
+
+let runtimePromise: Promise<PlannotatorRuntime> | null = null;
+
+export default function plannotatorAmpPlugin(amp: PluginAPI) {
+	amp.logger.log("[plannotator] Amp plugin initialized");
+
+	amp.registerCommand(
+		"plannotator-review",
+		{
+			title: "Review changes",
+			category: CATEGORY,
+			description: "Open Plannotator code review for the current workspace changes.",
+		},
+		async (ctx) => {
+			const result = await runPlannotator(amp, ctx, ["review"]);
+			await handleReviewResult(ctx, result);
+		},
+	);
+
+	amp.registerCommand(
+		"plannotator-review-target",
+		{
+			title: "Review changes or PR",
+			category: CATEGORY,
+			description:
+				"Open Plannotator code review for local changes, a PR/MR URL, or review arguments.",
+		},
+		async (ctx) => {
+			const target = await ctx.ui.input({
+				title: "Review changes or PR",
+				helpText:
+					"Leave blank for local git changes, or enter a GitHub PR/GitLab MR URL or review arguments such as --git.",
+				submitButtonText: "Review",
+			});
+
+			const reviewArgs = parseReviewTargetInput(target);
+			if (!reviewArgs) return;
+
+			const result = await runPlannotator(amp, ctx, ["review", ...reviewArgs]);
+			await handleReviewResult(ctx, result);
+		},
+	);
+
+	amp.registerCommand(
+		"plannotator-annotate",
+		{
+			title: "Annotate file",
+			category: CATEGORY,
+			description: "Open Plannotator annotation UI for a markdown/html file, folder, or URL.",
+		},
+		async (ctx) => {
+			const target = await ctx.ui.input({
+				title: "Annotate",
+				helpText: "Enter a markdown/html file, folder, or URL.",
+				submitButtonText: "Annotate",
+			});
+			if (!target?.trim()) return;
+
+			const args = splitCommandArgs(target);
+			if (args.length === 0) return;
+			const filePath = findFirstPositionalArg(args) ?? args[0];
+
+			const result = await runPlannotator(amp, ctx, ["annotate", ...args, "--json"]);
+			await handleAnnotateResult(ctx, result, { kind: "file", filePath });
+		},
+	);
+
+	amp.registerCommand(
+		"plannotator-last",
+		{
+			title: "Annotate last answer",
+			category: CATEGORY,
+			description: "Open Plannotator annotation UI for Amp's latest assistant message.",
+		},
+		async (ctx) => {
+			if (!ctx.thread) {
+				await ctx.ui.notify("No active Amp thread.");
+				return;
+			}
+
+			const message = await getLatestAssistantText(ctx);
+			if (!message) {
+				await ctx.ui.notify("No assistant message found in this thread.");
+				return;
+			}
+
+			const runtime = await getPlannotatorRuntime();
+			let tempFile: string | null = null;
+			let result: RunResult;
+
+			try {
+				if (runtime.features.stdinLast) {
+					result = await runPlannotator(amp, ctx, ["annotate-last", "--stdin", "--json"], {
+						stdin: message,
+						runtime,
+					});
+				} else {
+					tempFile = join(
+						tmpdir(),
+						`plannotator-amp-last-${process.pid}-${Date.now()}-${randomUUID()}.md`,
+					);
+					writeFileSync(tempFile, message, "utf8");
+					result = await runPlannotator(amp, ctx, ["annotate", tempFile, "--json"], { runtime });
+				}
+			} finally {
+				if (tempFile) {
+					try {
+						unlinkSync(tempFile);
+					} catch {
+						// Best-effort cleanup for the fallback message file.
+					}
+				}
+			}
+
+			await handleAnnotateResult(ctx, result, { kind: "message" });
+		},
+	);
+}
+
+export function extractTextFromThreadMessage(message: ThreadMessage): string {
+	if (message.role !== "assistant") return "";
+	return message.content
+		.filter((block) => block.type === "text" && block.text.trim())
+		.map((block) => block.text.trim())
+		.join("\n\n")
+		.trim();
+}
+
+export function parseAnnotateDecision(raw: string): AnnotateDecision | null {
+	const trimmed = raw.trim();
+	if (!trimmed) return { decision: "dismissed" };
+
+	try {
+		const parsed = JSON.parse(trimmed) as Partial<AnnotateDecision>;
+		if (
+			parsed &&
+			(parsed.decision === "approved" ||
+				parsed.decision === "dismissed" ||
+				parsed.decision === "annotated")
+		) {
+			return {
+				decision: parsed.decision,
+				feedback: typeof parsed.feedback === "string" ? parsed.feedback : undefined,
+			};
+		}
+	} catch {
+		return null;
+	}
+
+	return null;
+}
+
+export function formatAnnotationFeedback(
+	decision: AnnotateDecision,
+	options: { kind: "file"; filePath: string } | { kind: "message" },
+): string | null {
+	if (decision.decision !== "annotated") return null;
+
+	const feedback = decision.feedback?.trim();
+	if (!feedback || isNoActionFeedback(feedback)) return null;
+
+	const config = loadPlannotatorConfig();
+	if (options.kind === "file") {
+		const template = getConfiguredPrompt(
+			config,
+			"fileFeedback",
+			DEFAULT_ANNOTATE_FILE_FEEDBACK_PROMPT,
+		);
+		return resolveTemplate(template, {
+			fileHeader: "File",
+			filePath: options.filePath,
+			feedback,
+		});
+	}
+
+	const template = getConfiguredPrompt(
+		config,
+		"messageFeedback",
+		DEFAULT_ANNOTATE_MESSAGE_FEEDBACK_PROMPT,
+	);
+	return resolveTemplate(template, { feedback });
+}
+
+export function isNoActionFeedback(output: string): boolean {
+	const normalized = output.trim().toLowerCase();
+	return (
+		normalized === "" ||
+		normalized === "review session closed without feedback." ||
+		normalized === "annotation session closed." ||
+		normalized === "approved." ||
+		normalized === "the user approved." ||
+		normalized.includes("has no feedback")
+	);
+}
+
+export function splitCommandArgs(input: string): string[] {
+	const args: string[] = [];
+	let current = "";
+	let quote: "'" | '"' | null = null;
+
+	const text = input.trim();
+	for (let i = 0; i < text.length; i += 1) {
+		const char = text[i];
+
+		if (char === "\\" && quote !== "'") {
+			const next = text[i + 1];
+			const escapesNext =
+				next !== undefined &&
+				(next === "\\" ||
+					/\s/.test(next) ||
+					next === quote ||
+					(!quote && (next === "'" || next === '"')));
+
+			if (escapesNext) {
+				current += next;
+				i += 1;
+			} else {
+				current += char;
+			}
+			continue;
+		}
+
+		if (quote) {
+			if (char === quote) {
+				quote = null;
+			} else {
+				current += char;
+			}
+			continue;
+		}
+
+		if (char === "'" || char === '"') {
+			quote = char;
+			continue;
+		}
+
+		if (/\s/.test(char)) {
+			if (current) {
+				args.push(current);
+				current = "";
+			}
+			continue;
+		}
+
+		current += char;
+	}
+
+	if (current) args.push(current);
+	return args;
+}
+
+export function findFirstPositionalArg(args: string[]): string | null {
+	for (let i = 0; i < args.length; i += 1) {
+		const arg = args[i];
+		if (arg === "--") return args[i + 1] ?? null;
+		if (arg === "--browser") {
+			i += 1;
+			continue;
+		}
+		if (!arg.startsWith("-")) return arg;
+	}
+
+	return null;
+}
+
+export function parseReviewTargetInput(target: string | undefined): string[] | null {
+	if (target === undefined) return null;
+	return target.trim() ? splitCommandArgs(target) : [];
+}
+
+async function getLatestAssistantText(ctx: CommandContext): Promise<string | null> {
+	if (!ctx.thread) return null;
+
+	const latest = await ctx.thread.messages({ from: "end", limit: 1, roles: ["assistant"] });
+	const latestText = latest.map(extractTextFromThreadMessage).find(Boolean);
+	if (latestText) return latestText;
+
+	const recent = await ctx.thread.messages({ from: "end", limit: 20, roles: ["assistant"] });
+	for (let i = recent.length - 1; i >= 0; i -= 1) {
+		const text = extractTextFromThreadMessage(recent[i]);
+		if (text) return text;
+	}
+
+	return null;
+}
+
+async function handleReviewResult(ctx: CommandContext, result: RunResult): Promise<void> {
+	if (await notifyFailure(ctx, result, "review")) return;
+
+	const output = result.stdout.trim();
+	if (isNoActionFeedback(output)) {
+		await ctx.ui.notify(output || "Review session closed without feedback.");
+		return;
+	}
+
+	await appendFeedback(ctx, output);
+}
+
+async function handleAnnotateResult(
+	ctx: CommandContext,
+	result: RunResult,
+	options: { kind: "file"; filePath: string } | { kind: "message" },
+): Promise<void> {
+	if (await notifyFailure(ctx, result, "annotate")) return;
+
+	const decision = parseAnnotateDecision(result.stdout);
+	if (decision?.decision === "approved") {
+		await ctx.ui.notify("Approved.");
+		return;
+	}
+	if (decision?.decision === "dismissed") {
+		await ctx.ui.notify("Annotation session closed.");
+		return;
+	}
+
+	const feedback = decision ? formatAnnotationFeedback(decision, options) : result.stdout.trim();
+
+	if (!feedback || isNoActionFeedback(feedback)) {
+		await ctx.ui.notify("Annotation session closed without feedback.");
+		return;
+	}
+
+	await appendFeedback(ctx, feedback);
+}
+
+async function appendFeedback(ctx: CommandContext, content: string): Promise<void> {
+	if (!ctx.thread) {
+		await ctx.ui.notify("Plannotator produced feedback, but there is no active Amp thread.");
+		return;
+	}
+
+	await ctx.thread.append([{ type: "user-message", content }]);
+}
+
+async function notifyFailure(
+	ctx: CommandContext,
+	result: RunResult,
+	mode: "review" | "annotate",
+): Promise<boolean> {
+	if (!result.error && result.status === 0) return false;
+
+	const details = [result.error, result.stderr.trim(), result.stdout.trim()]
+		.filter(Boolean)
+		.join("\n")
+		.trim();
+	const missingExecutable =
+		/\bENOENT\b/i.test(details) ||
+		/executable not found/i.test(details) ||
+		/command not found/i.test(details);
+	const installHint = missingExecutable ? `\n\nInstall the CLI first: ${INSTALL_URL}` : "";
+
+	await ctx.ui.notify(
+		`Plannotator ${mode} failed.${details ? `\n\n${details}` : ""}${installHint}`,
+	);
+	return true;
+}
+
+async function runPlannotator(
+	amp: PluginAPI,
+	ctx: CommandContext,
+	args: string[],
+	options: { stdin?: string; runtime?: PlannotatorRuntime } = {},
+): Promise<RunResult> {
+	const cwd = await resolveCwd(ctx);
+	const runtime = options.runtime ?? (await getPlannotatorRuntime());
+	const readyFile = runtime.features.readyFile
+		? join(tmpdir(), `plannotator-amp-${process.pid}-${Date.now()}-${randomUUID()}.jsonl`)
+		: null;
+	const command = [...runtime.command, ...args];
+	const env = buildEnv(buildPlannotatorEnv(cwd, readyFile));
+
+	let proc: Bun.Subprocess<"ignore" | "pipe", "pipe", "pipe">;
+	try {
+		proc = Bun.spawn(command, {
+			cwd,
+			env,
+			stdin: options.stdin ? "pipe" : "ignore",
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+	} catch (error) {
+		return {
+			status: 1,
+			stdout: "",
+			stderr: "",
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+
+	if (options.stdin && proc.stdin) {
+		proc.stdin.write(options.stdin);
+		proc.stdin.end();
+	}
+
+	const exitState: ExitState = { done: false };
+	const stdoutPromise = new Response(proc.stdout).text();
+	const stderrPromise = collectStderr(amp, ctx, proc.stderr);
+	const exitedPromise = proc.exited.finally(() => {
+		exitState.done = true;
+	});
+
+	let readyPromise: Promise<ReadyResult> | null = null;
+	if (readyFile) {
+		readyPromise = waitForReadyFile(readyFile, exitState);
+		const readyResult = await readyPromise;
+		if (readyResult === "timeout") {
+			try {
+				proc.kill();
+			} catch {
+				// Process may already have exited.
+			}
+		}
+	}
+
+	const status = await exitedPromise;
+	const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
+
+	try {
+		if (readyFile) unlinkSync(readyFile);
+	} catch {
+		// Temporary ready file may not exist if the command failed early.
+	}
+
+	const readyTimedOut = readyPromise ? (await readyPromise) === "timeout" : false;
+	return {
+		status,
+		stdout,
+		stderr,
+		...(readyTimedOut
+			? { error: "Timed out waiting for Plannotator to publish its browser URL." }
+			: {}),
+	};
+}
+
+export async function resolveCwd(ctx: CommandContext): Promise<string> {
+	const explicitCwd = normalizeDirectory(process.env.PLANNOTATOR_CWD);
+	if (explicitCwd) return explicitCwd;
+
+	const ampWorkspaceRoot = resolveAmpWorkspaceRoot();
+	if (ampWorkspaceRoot) return ampWorkspaceRoot;
+
+	try {
+		const result = await ctx.$`pwd`;
+		const cwd = normalizeDirectory(result.stdout);
+		if (cwd) return cwd;
+	} catch {
+		// Fall through to process-level cwd fallbacks.
+	}
+
+	const shellPwd = normalizeDirectory(process.env.PWD);
+	if (shellPwd) return shellPwd;
+
+	return normalizeDirectory(process.cwd()) ?? process.cwd();
+}
+
+export function resolveAmpWorkspaceRoot(
+	options: { logPath?: string; parentPid?: number } = {},
+): string | null {
+	const logPath =
+		options.logPath ?? process.env.AMP_LOG_FILE ?? join(getAmpCacheDir(), "logs", "cli.log");
+	if (!existsSync(logPath)) return null;
+
+	const parentPid = options.parentPid ?? process.ppid;
+	const lines = readFileSync(logPath, "utf8").split(/\r?\n/).filter(Boolean);
+	let latestWorkspace: string | null = null;
+
+	for (let i = lines.length - 1; i >= 0; i -= 1) {
+		let entry: { pid?: unknown; workspaceRoot?: unknown };
+		try {
+			entry = JSON.parse(lines[i]) as { pid?: unknown; workspaceRoot?: unknown };
+		} catch {
+			continue;
+		}
+
+		const workspace = normalizeWorkspaceRoot(entry.workspaceRoot);
+		if (!workspace) continue;
+
+		latestWorkspace ??= workspace;
+		if (entry.pid === parentPid) return workspace;
+	}
+
+	return latestWorkspace;
+}
+
+function normalizeWorkspaceRoot(value: unknown): string | null {
+	if (typeof value !== "string" || !value.trim()) return null;
+
+	try {
+		const path = value.startsWith("file://") ? fileUrlToPath(value) : value;
+		return normalizeDirectory(path);
+	} catch {
+		return null;
+	}
+}
+
+function fileUrlToPath(value: string): string {
+	const url = new URL(value);
+	if (url.protocol !== "file:") throw new Error(`Unsupported URL protocol: ${url.protocol}`);
+
+	const pathname = decodeURIComponent(url.pathname);
+	return process.platform === "win32" && /^\/[A-Za-z]:/.test(pathname)
+		? pathname.slice(1)
+		: pathname;
+}
+
+export function buildPlannotatorEnv(cwd: string, readyFile: string | null): Record<string, string> {
+	return {
+		PLANNOTATOR_ORIGIN: RUNTIME,
+		PLANNOTATOR_CWD: cwd,
+		...(readyFile ? { PLANNOTATOR_READY_FILE: readyFile } : {}),
+	};
+}
+
+function normalizeDirectory(value: string | undefined): string | null {
+	const candidate = value?.trim();
+	if (!candidate || candidate === "undefined" || candidate === "null") return null;
+
+	try {
+		return statSync(candidate).isDirectory() ? candidate : null;
+	} catch {
+		return null;
+	}
+}
+
+export function buildEnv(extra: Record<string, string>): Record<string, string> {
+	const env: Record<string, string> = {};
+	for (const [key, value] of Object.entries(process.env)) {
+		if (typeof value === "string") env[key] = value;
+	}
+	delete env.BUN_BE_BUN;
+	return { ...env, ...extra };
+}
+
+async function collectStderr(
+	amp: PluginAPI,
+	ctx: CommandContext,
+	stream: ReadableStream<Uint8Array>,
+): Promise<string> {
+	const decoder = new TextDecoder();
+	const reader = stream.getReader();
+	const seenUrls = new Set<string>();
+	let output = "";
+	let lineBuffer = "";
+
+	while (true) {
+		const { value, done } = await reader.read();
+		if (done) break;
+
+		const text = decoder.decode(value, { stream: true });
+		output += text;
+		lineBuffer += text;
+
+		const lines = lineBuffer.split(/\r?\n/);
+		lineBuffer = lines.pop() ?? "";
+		for (const line of lines) {
+			await notifyUrls(ctx, line, seenUrls);
+		}
+	}
+
+	const tail = decoder.decode();
+	output += tail;
+	if (tail) lineBuffer += tail;
+	if (lineBuffer) await notifyUrls(ctx, lineBuffer, seenUrls);
+
+	if (output.trim()) amp.logger.log(output.trim());
+	return output;
+}
+
+async function notifyUrls(ctx: CommandContext, text: string, seenUrls: Set<string>): Promise<void> {
+	const matches = text.match(/https?:\/\/[^\s)]+/g) ?? [];
+	for (const rawUrl of matches) {
+		const url = rawUrl.replace(/[.,;]+$/, "");
+		if (seenUrls.has(url)) continue;
+		seenUrls.add(url);
+		await ctx.ui.notify(`Plannotator link:\n${url}`);
+	}
+}
+
+async function waitForReadyFile(readyFile: string, exitState: ExitState): Promise<ReadyResult> {
+	const deadline = Date.now() + READY_TIMEOUT_MS;
+	const seen = new Set<string>();
+
+	while (Date.now() < deadline) {
+		if (existsSync(readyFile)) {
+			const lines = readFileSync(readyFile, "utf8").split(/\r?\n/).filter(Boolean);
+			for (const line of lines) {
+				let payload: { url?: unknown };
+				try {
+					payload = JSON.parse(line) as { url?: unknown };
+				} catch {
+					// Keep polling; the writer may still be appending the line.
+					continue;
+				}
+
+				if (typeof payload.url !== "string" || seen.has(payload.url)) continue;
+				seen.add(payload.url);
+				return "ready";
+			}
+		}
+
+		if (exitState.done) return "exited";
+		await sleep(100);
+	}
+
+	return "timeout";
+}
+
+async function getPlannotatorRuntime(): Promise<PlannotatorRuntime> {
+	runtimePromise ??= resolvePlannotatorRuntime();
+	return runtimePromise;
+}
+
+async function resolvePlannotatorRuntime(): Promise<PlannotatorRuntime> {
+	const explicitSource = process.env.PLANNOTATOR_AMP_SOURCE_ENTRY;
+	const sourceEntry = explicitSource
+		? resolve(explicitSource)
+		: process.env.PLANNOTATOR_AMP_USE_SOURCE === "1"
+			? findSourceEntry(import.meta.dir)
+			: null;
+
+	if (sourceEntry && existsSync(sourceEntry)) {
+		return {
+			command: [getBunExecutable(), sourceEntry],
+			source: "source",
+			version: "source",
+			features: { readyFile: true, stdinLast: true },
+		};
+	}
+
+	const { command, version } = resolvePlannotatorCommand();
+	return {
+		command,
+		source: "cli",
+		version,
+		features: {
+			readyFile: semverGte(version, MIN_READY_FILE_VERSION),
+			stdinLast: semverGte(version, MIN_STDIN_LAST_VERSION),
+		},
+	};
+}
+
+function resolvePlannotatorCommand(): { command: string[]; version: string | null } {
+	const candidates = getPlannotatorCommandCandidates();
+	let fallback = candidates[candidates.length - 1] ?? ["plannotator"];
+
+	for (const command of candidates) {
+		const executable = command[0];
+		if (!executable) continue;
+
+		if (isPathLike(executable)) {
+			if (!existsSync(executable)) continue;
+			const version = detectPlannotatorVersion(command);
+			return { command, version };
+		}
+
+		fallback = command;
+		const version = detectPlannotatorVersion(command);
+		if (version) return { command, version };
+	}
+
+	return { command: fallback, version: detectPlannotatorVersion(fallback) };
+}
+
+export function getPlannotatorCommandCandidates(
+	options: {
+		env?: Record<string, string | undefined>;
+		home?: string;
+		pluginDir?: string;
+		platform?: string;
+	} = {},
+): string[][] {
+	const env = options.env ?? process.env;
+	const homes = getHomeDirectoryCandidates(env, options.home, options.pluginDir ?? import.meta.dir);
+	const platform = options.platform ?? process.platform;
+	const candidates: string[][] = [];
+
+	const explicitBin = normalizeExecutablePath(env.PLANNOTATOR_BIN);
+	if (explicitBin) candidates.push([explicitBin]);
+
+	if (platform === "win32") {
+		const localAppData = normalizeExecutablePath(env.LOCALAPPDATA);
+		if (localAppData) candidates.push([join(localAppData, "plannotator", "plannotator.exe")]);
+
+		for (const home of homes) {
+			candidates.push([join(home, ".local", "bin", "plannotator.exe")]);
+		}
+	} else {
+		for (const home of homes) {
+			candidates.push([join(home, ".local", "bin", "plannotator")]);
+		}
+	}
+
+	candidates.push(["plannotator"]);
+	return dedupeCommands(candidates);
+}
+
+function normalizeExecutablePath(value: string | undefined): string | null {
+	const candidate = value?.trim();
+	if (!candidate || candidate === "undefined" || candidate === "null") return null;
+	return candidate;
+}
+
+function getHomeDirectoryCandidates(
+	env: Record<string, string | undefined>,
+	explicitHome: string | undefined,
+	pluginDir: string,
+): string[] {
+	return dedupeStrings([
+		normalizeExecutablePath(explicitHome),
+		normalizeExecutablePath(env.HOME),
+		normalizeExecutablePath(env.USERPROFILE),
+		deriveHomeFromAmpPluginDir(pluginDir),
+		explicitHome === undefined ? normalizeExecutablePath(homedir()) : null,
+	]);
+}
+
+function deriveHomeFromAmpPluginDir(pluginDir: string): string | null {
+	const pluginsDir = resolve(pluginDir);
+	const ampDir = dirname(pluginsDir);
+	const configDir = dirname(ampDir);
+
+	if (
+		basename(pluginsDir) === "plugins" &&
+		basename(ampDir) === "amp" &&
+		basename(configDir) === ".config"
+	) {
+		return dirname(configDir);
+	}
+
+	return null;
+}
+
+function getAmpCacheDir(): string {
+	const cacheHome = normalizeExecutablePath(process.env.XDG_CACHE_HOME);
+	return cacheHome ? join(cacheHome, "amp") : join(homedir(), ".cache", "amp");
+}
+
+function dedupeCommands(commands: string[][]): string[][] {
+	const seen = new Set<string>();
+	const deduped: string[][] = [];
+	for (const command of commands) {
+		const key = command.join("\0");
+		if (seen.has(key)) continue;
+		seen.add(key);
+		deduped.push(command);
+	}
+	return deduped;
+}
+
+function dedupeStrings(values: Array<string | null>): string[] {
+	const seen = new Set<string>();
+	const deduped: string[] = [];
+	for (const value of values) {
+		if (!value || seen.has(value)) continue;
+		seen.add(value);
+		deduped.push(value);
+	}
+	return deduped;
+}
+
+function isPathLike(command: string): boolean {
+	return command.includes("/") || command.includes("\\");
+}
+
+function findSourceEntry(startDir: string): string | null {
+	const root = findRepoRoot(startDir);
+	if (!root) return null;
+
+	const sourceEntry = join(root, "apps", "hook", "server", "index.ts");
+	return existsSync(sourceEntry) ? sourceEntry : null;
+}
+
+function findRepoRoot(startDir: string): string | null {
+	let dir = resolve(startDir);
+
+	while (true) {
+		const packageJsonPath = join(dir, "package.json");
+		if (existsSync(packageJsonPath)) {
+			try {
+				const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8")) as { name?: unknown };
+				if (pkg.name === "plannotator") return dir;
+			} catch {
+				// Ignore malformed package.json while walking upward.
+			}
+		}
+
+		const parent = dirname(dir);
+		if (parent === dir) return null;
+		dir = parent;
+	}
+}
+
+function getBunExecutable(): string {
+	const candidates = [process.execPath, Bun.argv[0], Bun.which?.("bun"), "bun"];
+	for (const candidate of candidates) {
+		if (typeof candidate !== "string") continue;
+		const value = candidate.trim();
+		if (!value || value === "undefined" || value === "null") continue;
+		return value;
+	}
+
+	return "bun";
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+function detectPlannotatorVersion(command: string[]): string | null {
+	try {
+		const result = Bun.spawnSync([...command, "--version"], {
+			stdout: "pipe",
+			stderr: "pipe",
+		});
+		if (result.exitCode !== 0) return null;
+
+		const output = new TextDecoder().decode(result.stdout).trim();
+		const match = output.match(/\b(\d+\.\d+\.\d+)\b/);
+		return match?.[1] ?? null;
+	} catch {
+		return null;
+	}
+}
+
+function semverGte(actual: string | null, minimum: string): boolean {
+	if (!actual) return false;
+	const actualParts = actual.split(".").map((part) => Number(part));
+	const minimumParts = minimum.split(".").map((part) => Number(part));
+
+	for (let i = 0; i < 3; i += 1) {
+		const actualPart = actualParts[i] ?? 0;
+		const minimumPart = minimumParts[i] ?? 0;
+		if (actualPart > minimumPart) return true;
+		if (actualPart < minimumPart) return false;
+	}
+
+	return true;
+}
+
+type PromptConfig = {
+	prompts?: {
+		annotate?: {
+			fileFeedback?: unknown;
+			messageFeedback?: unknown;
+			runtimes?: Partial<
+				Record<
+					typeof RUNTIME,
+					{
+						fileFeedback?: unknown;
+						messageFeedback?: unknown;
+					}
+				>
+			>;
+		};
+	};
+};
+
+function loadPlannotatorConfig(): PromptConfig {
+	try {
+		const configPath = join(getPlannotatorDataDir(), "config.json");
+		if (!existsSync(configPath)) return {};
+
+		const parsed = JSON.parse(readFileSync(configPath, "utf8")) as unknown;
+		return parsed && typeof parsed === "object" ? (parsed as PromptConfig) : {};
+	} catch {
+		return {};
+	}
+}
+
+export function getPlannotatorDataDir(): string {
+	const value = process.env.PLANNOTATOR_DATA_DIR?.trim();
+	if (!value) return join(homedir(), ".plannotator");
+
+	const home = homedir();
+	if (value === "~") return home;
+	if (value.startsWith("~/") || value.startsWith("~\\")) {
+		return join(home, value.slice(2));
+	}
+
+	return resolve(value);
+}
+
+function getConfiguredPrompt(
+	config: PromptConfig,
+	key: "fileFeedback" | "messageFeedback",
+	fallback: string,
+): string {
+	const annotate = config.prompts?.annotate;
+	const runtimePrompt = normalizePrompt(annotate?.runtimes?.[RUNTIME]?.[key]);
+	const genericPrompt = normalizePrompt(annotate?.[key]);
+	return runtimePrompt ?? genericPrompt ?? fallback;
+}
+
+function normalizePrompt(prompt: unknown): string | undefined {
+	if (typeof prompt !== "string") return undefined;
+	return prompt.trim() ? prompt : undefined;
+}
+
+function resolveTemplate(template: string, vars: Record<string, string | undefined>): string {
+	return template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+		const value = vars[key];
+		return value !== undefined ? value : match;
+	});
+}

--- a/configs/amp/plugins/plannotator.ts
+++ b/configs/amp/plugins/plannotator.ts
@@ -145,7 +145,7 @@ export default function plannotatorAmpPlugin(amp: PluginAPI) {
 						tmpdir(),
 						`plannotator-amp-last-${process.pid}-${Date.now()}-${randomUUID()}.md`,
 					);
-					writeFileSync(tempFile, message, "utf8");
+					writeFileSync(tempFile, message, { encoding: "utf8", mode: 0o600 });
 					result = await runPlannotator(amp, ctx, ["annotate", tempFile, "--json"], { runtime });
 				}
 			} finally {
@@ -508,7 +508,6 @@ export function resolveAmpWorkspaceRoot(
 
 	const parentPid = options.parentPid ?? process.ppid;
 	const lines = readFileSync(logPath, "utf8").split(/\r?\n/).filter(Boolean);
-	let latestWorkspace: string | null = null;
 
 	for (let i = lines.length - 1; i >= 0; i -= 1) {
 		let entry: { pid?: unknown; workspaceRoot?: unknown };
@@ -521,11 +520,10 @@ export function resolveAmpWorkspaceRoot(
 		const workspace = normalizeWorkspaceRoot(entry.workspaceRoot);
 		if (!workspace) continue;
 
-		latestWorkspace ??= workspace;
 		if (entry.pid === parentPid) return workspace;
 	}
 
-	return latestWorkspace;
+	return null;
 }
 
 function normalizeWorkspaceRoot(value: unknown): string | null {

--- a/generate.sh
+++ b/generate.sh
@@ -148,6 +148,21 @@ generate_claude_configs() {
 	log_success "Claude Code configs generated"
 }
 
+copy_directory() {
+	local src="$1"
+	local dest="$2"
+	if [ ! -d "$src" ]; then
+		log_warning "Source directory not found: $src"
+		return 1
+	fi
+	execute_quoted mkdir -p "$dest"
+	if execute_quoted cp -r "$src"/. "$dest"/ 2>/dev/null; then
+		log_success "Copied: $src → $dest"
+	else
+		log_warning "Failed to copy: $src → $dest"
+	fi
+}
+
 copy_claude_settings() {
 	local settings_source=""
 

--- a/generate.sh
+++ b/generate.sh
@@ -41,18 +41,6 @@ copy_single() {
 	fi
 }
 
-copy_directory() {
-	local src="$1"
-	local dest="$2"
-	if [ -d "$src" ]; then
-		execute_quoted mkdir -p "$dest"
-		execute_quoted cp -r "$src"/. "$dest"/ 2>/dev/null || true
-		log_success "Copied directory: $src → $dest"
-	else
-		log_warning "Skipped (not found): $src"
-	fi
-}
-
 # Copy a Claude subdirectory with proper logging
 # Usage: copy_claude_subdirectory "source_path" "dest_path" "name_for_logging"
 copy_claude_subdirectory() {
@@ -249,7 +237,9 @@ generate_amp_configs() {
 	copy_skills_with_filter "$HOME/.config/amp/skills" "$SCRIPT_DIR/configs/amp/skills" "Amp"
 
 	# Copy plugins
-	[ -d "$HOME/.config/amp/plugins" ] && copy_directory "$HOME/.config/amp/plugins" "$SCRIPT_DIR/configs/amp/plugins"
+	if [ -d "$HOME/.config/amp/plugins" ]; then
+		safe_copy_dir "$HOME/.config/amp/plugins" "$SCRIPT_DIR/configs/amp/plugins"
+	fi
 
 	log_success "Amp configs generated"
 }

--- a/generate.sh
+++ b/generate.sh
@@ -248,6 +248,9 @@ generate_amp_configs() {
 
 	copy_skills_with_filter "$HOME/.config/amp/skills" "$SCRIPT_DIR/configs/amp/skills" "Amp"
 
+	# Copy plugins
+	[ -d "$HOME/.config/amp/plugins" ] && copy_directory "$HOME/.config/amp/plugins" "$SCRIPT_DIR/configs/amp/plugins"
+
 	log_success "Amp configs generated"
 }
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -659,7 +659,7 @@ safe_copy_dir() {
 
 	# Directories to exclude from copies
 	local -a exclude_dirs=(
-		"node_modules" "plugins" "projects" "debug" "sessions" "git"
+		"node_modules" "plugins" "projects" "debug" "sessions" ".git"
 		"cache" "extensions" "chats" "antigravity" "antigravity-browser-profile"
 		"log" "logs" "tmp" "vendor_imports" "file-history" "ai-tracking"
 	)
@@ -684,10 +684,13 @@ safe_copy_dir() {
 	prune_expr="${prune_expr% -o}"
 
 	mkdir -p "$dest_dir"
+	# Don't prune the source root itself, only matching subdirectories.
+	# This prevents pruning when the source directory is named after an
+	# excluded directory (e.g. amp/plugins).
 	# POSIX: use temp file instead of process substitution so the loop runs in the current shell
 	local _find_list
 	_find_list=$(make_temp_file "safe-copy-find" "list")
-	find "$source_dir" -type d \( $prune_expr \) -prune -o -type f -print 2>/dev/null > "$_find_list"
+	find "$source_dir" -type d \( $prune_expr ! -path "$source_dir" \) -prune -o -type f -print 2>/dev/null > "$_find_list"
 	while IFS= read -r file; do
 		case "$file" in *.sqlite | *.sqlite-wal | *.sqlite-shm) continue ;; esac
 		local rel_path="${file#"$source_dir"/}"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -639,6 +639,72 @@ end_transaction() {
 	fi
 }
 
+# Helper: Safely copy a directory, handling "Text file busy" errors
+# Usage: safe_copy_dir "source_dir" "dest_dir"
+safe_copy_dir() {
+	local source_dir="$1"
+	local dest_dir="$2"
+	local skipped=0
+	local errors=0
+
+	if [ "${DRY_RUN:-false}" = true ]; then
+		log_info "[DRY RUN] Would copy $source_dir to $dest_dir"
+		return 0
+	fi
+
+	if ! mkdir -p "$(dirname "$dest_dir")" 2>/dev/null; then
+		log_warning "Failed to create destination directory: $(dirname "$dest_dir")"
+		return 1
+	fi
+
+	# Directories to exclude from copies
+	local -a exclude_dirs=(
+		"node_modules" "plugins" "projects" "debug" "sessions" "git"
+		"cache" "extensions" "chats" "antigravity" "antigravity-browser-profile"
+		"log" "logs" "tmp" "vendor_imports" "file-history" "ai-tracking"
+	)
+
+	# Prefer rsync when available
+	if command -v rsync &>/dev/null; then
+		local -a rsync_excludes=()
+		for dir in "${exclude_dirs[@]}"; do
+			rsync_excludes+=(--exclude "$dir" --exclude "$dir/**")
+		done
+		rsync_excludes+=(--exclude "*.sqlite" --exclude "*.sqlite-wal" --exclude "*.sqlite-shm")
+		if rsync -a --ignore-errors "${rsync_excludes[@]}" "$source_dir/" "$dest_dir/" 2>/dev/null; then
+			return 0
+		fi
+	fi
+
+	# Fallback: manual copy
+	local prune_expr=""
+	for dir in "${exclude_dirs[@]}"; do
+		prune_expr="$prune_expr -name $dir -o"
+	done
+	prune_expr="${prune_expr% -o}"
+
+	mkdir -p "$dest_dir"
+	# POSIX: use temp file instead of process substitution so the loop runs in the current shell
+	local _find_list
+	_find_list=$(make_temp_file "safe-copy-find" "list")
+	find "$source_dir" -type d \( $prune_expr \) -prune -o -type f -print 2>/dev/null > "$_find_list"
+	while IFS= read -r file; do
+		case "$file" in *.sqlite | *.sqlite-wal | *.sqlite-shm) continue ;; esac
+		local rel_path="${file#"$source_dir"/}"
+		local dest_file="$dest_dir/$rel_path"
+		mkdir -p "$(dirname "$dest_file")"
+		if ! cp "$file" "$dest_file" 2>/dev/null; then
+			((errors++))
+			((skipped++))
+			[ "${VERBOSE:-false}" = true ] && log_warning "Skipped busy file: $rel_path"
+		fi
+	done < "$_find_list"
+	rm -f "$_find_list"
+
+	[ "${VERBOSE:-false}" = true ] && [ $skipped -gt 0 ] && log_info "Skipped $skipped busy file(s)"
+	return 0
+}
+
 # Cleanup plugin cache with proper error handling
 # Usage: cleanup_plugin_cache "cli_tool" "plugin_name"
 # Returns: 0 on success or if directory doesn't exist, 1 on permission/other errors


### PR DESCRIPTION
## What

- Migrate Conductor config from `conductor.json` to `.conductor/settings.toml`
- Add bidirectional Amp plugin sync: install from repo (`cli.sh`) and export back to repo (`generate.sh`)

## Why

The Conductor project has migrated from `conductor.json` to `.conductor/settings.toml` for their settings format. Amp plugins needed the same bidirectional sync pattern already used for Amp skills to support plugin development and distribution.

## How

- `cli.sh`: `copy_amp_configs()` now iterates over `configs/amp/plugins/*` and copies each plugin directory via `safe_copy_dir`
- `generate.sh`: `generate_amp_configs()` now exports plugins from `~/.config/amp/plugins` back to the repo using the existing `copy_directory` helper
- Deleted `conductor.json` in favour of the TOML-based `.conductor/settings.toml`

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated
- [x] No breaking changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GLM-5.2 experimental agent mode with advanced reasoning capabilities.
  * Added Orca agent hook integration for forwarding lifecycle events.
  * Added Plannotator integration for reviewing and annotating workspace changes.

* **Chores**
  * Improved Amp plugin directory handling during installation and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->