### PR TITLE
fix(ai-launcher): always install latest version from GitHub releases

### DIFF
--- a/.changeset/always-install-latest-ai-launcher.md
+++ b/.changeset/always-install-latest-ai-launcher.md
@@ -1,0 +1,5 @@
+---
+"my-ai-tools": patch
+---
+
+fix(ai-launcher): always install latest version from GitHub releases; fix empty check_cmd bug

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -716,13 +716,12 @@ install_ccs() {
 install_ai_switcher() {
 	_run_ai_switcher_install() {
 		if command -v ai &>/dev/null; then
-			log_warning "AI Launcher is already installed"
-		else
-			execute_installer "https://raw.githubusercontent.com/jellydn/ai-launcher/main/install.sh" "" "AI Launcher"
-			log_success "AI Launcher installed"
+			log_info "Upgrading AI Launcher from existing installation..."
 		fi
+		execute_installer "https://raw.githubusercontent.com/jellydn/ai-launcher/main/install.sh" "" "AI Launcher"
+		log_success "AI Launcher installed/upgraded"
 	}
-	run_installer "AI Launcher" "_run_ai_switcher_install" "command -v ai" "ai --version"
+	run_installer "AI Launcher" "_run_ai_switcher_install" "" "ai --version"
 }
 
 install_codex() {

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -721,7 +721,7 @@ install_ai_switcher() {
 		execute_installer "https://raw.githubusercontent.com/jellydn/ai-launcher/main/install.sh" "" "AI Launcher"
 		log_success "AI Launcher installed/upgraded"
 	}
-	run_installer "AI Launcher" "_run_ai_switcher_install" "" "ai --version"
+	run_installer "AI Launcher" "_run_ai_switcher_install" "false" "ai --version"
 }
 
 install_codex() {


### PR DESCRIPTION
## What

Removes the redundant guard in `install_ai_switcher` that skipped AI Launcher installation when the binary already existed. This prevented upgrades from ever happening.

## Why

Running `./cli.sh` would detect the existing `ai` binary (v0.3.0) and skip reinstallation entirely — even though the latest release was v0.7.8. Users had to manually run `ai upgrade` or download the binary themselves.

## How

- Removed the inner `command -v ai` guard in `_run_ai_switcher_install` that returned early when `ai` existed
- Removed the `check_cmd` argument from `run_installer` so the install body always runs (the GitHub install script handles fresh install and overwrite correctly)
- Changed log level from `warning` to `info` when existing install detected
- Preserved `version_cmd` so the output still shows which version was installed

## Checklist

- [ ] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes (or breaking changes documented above)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The AI Launcher installer now always follows an upgrade flow, even when it’s already installed.
  * Users will see an “Upgrading AI Launcher…” message instead of the installer skipping action.
  * Installation has been updated to reliably fetch and install the latest GitHub release version and fix an empty install check condition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->