### PR TITLE
pr 279

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,6 +8,129 @@
 	},
 	"plugins": [
 		{
+			"name": "adr",
+			"description": "Manages Architecture Decision Records (ADR) for tracking important architectural decisions. Initialize, create, list, search, and view ADRs.",
+			"version": "1.0.0",
+			"author": {
+				"name": "Dung Huynh Duc",
+				"email": "dung@productsway.com"
+			},
+			"source": "./skills/adr",
+			"category": "productivity"
+		},
+		{
+			"name": "codemap",
+			"description": "Orchestrate parallel codebase analysis to produce 7 structured documents (STACK, INTEGRATIONS, ARCHITECTURE, STRUCTURE, CONVENTIONS, TESTING, CONCERNS) in .planning/codebase/.",
+			"version": "1.0.0",
+			"author": {
+				"name": "Dung Huynh Duc",
+				"email": "dung@productsway.com"
+			},
+			"source": "./skills/codemap",
+			"category": "productivity",
+			"homepage": "https://github.com/jellydn/my-ai-tools"
+		},
+		{
+			"name": "commit-atomic",
+			"description": "Creates atomic commits by logically grouping staged changes with commitizen convention",
+			"version": "1.0.0",
+			"author": {
+				"name": "Dung Huynh Duc",
+				"email": "dung@productsway.com"
+			},
+			"source": "./skills/commit-atomic",
+			"category": "productivity"
+		},
+		{
+			"name": "docs-update",
+			"description": "Update user-facing documentation when code changes. Use when asked to update docs, review docs, handle documentation changes, run scheduled documentation tasks, or analyze recent commits for documentation needs.",
+			"version": "1.0.0",
+			"author": {
+				"name": "Dung Huynh Duc",
+				"email": "dung@productsway.com"
+			},
+			"source": "./skills/docs-update",
+			"category": "productivity"
+		},
+		{
+			"name": "draft-pull-request",
+			"description": "Creates a draft pull request using gh CLI with a structured what/why/how description",
+			"version": "1.0.0",
+			"author": {
+				"name": "Dung Huynh Duc",
+				"email": "dung@productsway.com"
+			},
+			"source": "./skills/draft-pull-request",
+			"category": "productivity"
+		},
+		{
+			"name": "handoffs",
+			"description": "Creates detailed handoff plans of conversations for continuing work in new sessions. Capture context, technical decisions, and pending tasks for seamless session continuation.",
+			"version": "1.0.0",
+			"author": {
+				"name": "Dung Huynh Duc",
+				"email": "dung@productsway.com"
+			},
+			"source": "./skills/handoffs",
+			"category": "productivity"
+		},
+		{
+			"name": "llm-wiki",
+			"description": "Build and maintain a persistent, compounding knowledge wiki from raw sources. Use when the user wants to create a knowledge base, ingest documents into a wiki, query a wiki, health-check a wiki, or set up Karpathy's LLM Wiki pattern.",
+			"version": "1.0.0",
+			"author": {
+				"name": "Dung Huynh Duc",
+				"email": "dung@productsway.com"
+			},
+			"source": "./skills/llm-wiki",
+			"category": "productivity",
+			"homepage": "https://github.com/jellydn/my-ai-tools"
+		},
+		{
+			"name": "pickup",
+			"description": "Resumes work from previous handoff sessions stored in .planning/handoffs/. Load and continue from where you left off in prior sessions.",
+			"version": "1.0.0",
+			"author": {
+				"name": "Dung Huynh Duc",
+				"email": "dung@productsway.com"
+			},
+			"source": "./skills/pickup",
+			"category": "productivity"
+		},
+		{
+			"name": "plannotator-setup-goal",
+			"description": "Turn an idea into a structured goal package via Plannotator-gated discovery, fact sheet, and plan.",
+			"version": "1.0.0",
+			"author": {
+				"name": "Dung Huynh Duc",
+				"email": "dung@productsway.com"
+			},
+			"source": "./skills/plannotator-setup-goal",
+			"category": "productivity"
+		},
+		{
+			"name": "portless-local",
+			"description": "Named .localhost URLs for local development - replaces port numbers with stable, readable URLs",
+			"version": "1.0.0",
+			"author": {
+				"name": "Dung Huynh Duc",
+				"email": "dung@productsway.com"
+			},
+			"source": "./skills/portless-local",
+			"category": "productivity"
+		},
+		{
+			"name": "pr-review",
+			"description": "Fix PR review comments by implementing requested changes. Fetch review comments, implement fixes, run tests, and commit changes.",
+			"version": "1.0.0",
+			"author": {
+				"name": "Dung Huynh Duc",
+				"email": "dung@productsway.com"
+			},
+			"source": "./skills/pr-review",
+			"category": "productivity"
+		},
+		{
 			"name": "prd",
 			"description": "Generate Product Requirements Documents (PRD) for new features. Use when planning features, starting projects, or creating specifications.",
 			"version": "1.0.0",
@@ -16,17 +139,6 @@
 				"email": "dung@productsway.com"
 			},
 			"source": "./skills/prd",
-			"category": "productivity"
-		},
-		{
-			"name": "ralph",
-			"description": "Convert PRDs to prd.json format for the Ralph autonomous agent system. Converts markdown PRDs to Ralph's JSON format.",
-			"version": "1.0.0",
-			"author": {
-				"name": "Dung Huynh Duc",
-				"email": "dung@productsway.com"
-			},
-			"source": "./skills/ralph",
 			"category": "productivity"
 		},
 		{
@@ -42,70 +154,14 @@
 			"homepage": "https://github.com/jellydn/my-ai-tools"
 		},
 		{
-			"name": "codemap",
-			"description": "Orchestrate parallel codebase analysis to produce 7 structured documents (STACK, INTEGRATIONS, ARCHITECTURE, STRUCTURE, CONVENTIONS, TESTING, CONCERNS) in .planning/codebase/.",
+			"name": "ralph",
+			"description": "Convert PRDs to prd.json format for the Ralph autonomous agent system. Converts markdown PRDs to Ralph's JSON format.",
 			"version": "1.0.0",
 			"author": {
 				"name": "Dung Huynh Duc",
 				"email": "dung@productsway.com"
 			},
-			"source": "./skills/codemap",
-			"category": "productivity",
-			"homepage": "https://github.com/jellydn/my-ai-tools"
-		},
-		{
-			"name": "adr",
-			"description": "Manages Architecture Decision Records (ADR) for tracking important architectural decisions. Initialize, create, list, search, and view ADRs.",
-			"version": "1.0.0",
-			"author": {
-				"name": "Dung Huynh Duc",
-				"email": "dung@productsway.com"
-			},
-			"source": "./skills/adr",
-			"category": "productivity"
-		},
-		{
-			"name": "handoffs",
-			"description": "Creates detailed handoff plans of conversations for continuing work in new sessions. Capture context, technical decisions, and pending tasks for seamless session continuation.",
-			"version": "1.0.0",
-			"author": {
-				"name": "Dung Huynh Duc",
-				"email": "dung@productsway.com"
-			},
-			"source": "./skills/handoffs",
-			"category": "productivity"
-		},
-		{
-			"name": "plannotator-setup-goal",
-			"description": "Turn an idea into a structured goal package via Plannotator-gated discovery, fact sheet, and plan.",
-			"version": "1.0.0",
-			"author": {
-				"name": "Dung Huynh Duc",
-				"email": "dung@productsway.com"
-			},
-			"source": "./skills/plannotator-setup-goal",
-			"category": "productivity"
-		},
-		{
-			"name": "pickup",
-			"description": "Resumes work from previous handoff sessions stored in .planning/handoffs/. Load and continue from where you left off in prior sessions.",
-			"version": "1.0.0",
-			"author": {
-				"name": "Dung Huynh Duc",
-				"email": "dung@productsway.com"
-			},
-			"source": "./skills/pickup",
-			"category": "productivity"
-		},
-		{
-			"name": "pr-review",
-			"description": "Fix PR review comments by implementing requested changes. Fetch review comments, implement fixes, run tests, and commit changes.",
-			"version": "1.0.0",
-			"author": {
-				"name": "Dung Huynh Duc",
-				"email": "dung@productsway.com"
-			},
-			"source": "./skills/pr-review",
+			"source": "./skills/ralph",
 			"category": "productivity"
 		},
 		{
@@ -129,6 +185,17 @@
 			},
 			"source": "./skills/tdd",
 			"category": "productivity"
+		},
+		{
+			"name": "thermo-nuclear-code-quality-review",
+			"description": "Run an extremely strict maintainability code quality review for abstraction quality, giant files, and spaghetti-condition growth. Catch deep structural issues before merging.",
+			"version": "1.0.0",
+			"author": {
+				"name": "Dung Huynh Duc",
+				"email": "dung@productsway.com"
+			},
+			"source": "./skills/thermo-nuclear-code-quality-review",
+			"category": "code-quality"
 		},
 		{
 			"name": "tmux",

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ npx skills add jellydn/my-ai-tools --yes --global --agent claude-code
 # Or install interactively (select which skills to install)
 npx skills add jellydn/my-ai-tools --global --agent claude-code
 
-# Available skills: prd, ralph, qmd-knowledge, codemap, adr, handoffs, pickup, pr-review, slop, tdd, thermo-nuclear-code-quality-review, commit-atomic, draft-pull-request, docs-update
+# Available skills: prd, ralph, qmd-knowledge, codemap, adr, handoffs, pickup, pr-review, slop, tdd, thermo-nuclear-code-quality-review, commit-atomic, draft-pull-request, docs-update, llm-wiki, plannotator-setup-goal, portless-local, tmux
 # Skills are installed to ~/.agents/skills/ with symlinks in ~/.claude/skills/
 ```
 
@@ -648,6 +648,7 @@ Located in [`configs/claude/agents/`](configs/claude/agents/):
 - `commit-atomic` - Atomic commits by logically grouping changes with commitizen convention (no `git add -A`)
 - `draft-pull-request` - Create draft pull requests using gh CLI with what/why/how template
 - `handoffs` - Create handoff plans for continuing work (provides `/handoffs` command)
+- `llm-wiki` - Build and maintain a persistent, compounding knowledge wiki from raw sources (Karpathy's LLM Wiki pattern)
 - `pickup` - Resume work from previous handoff sessions (provides `/pickup` command)
 - `plannotator-setup-goal` - Turn an idea into a structured goal package via Plannotator-gated discovery, fact sheet, and plan
 - `docs-update` - Automated documentation synchronization with code changes (Mintlify, Docusaurus, GitBook, Fumadocs, etc.)
@@ -659,6 +660,7 @@ Located in [`configs/claude/agents/`](configs/claude/agents/):
 - `slop` - AI slop detection and removal
 - `tdd` - Test-Driven Development workflows
 - `thermo-nuclear-code-quality-review` - Extremely strict maintainability and structural code quality reviews
+- `tmux` - Remote control tmux sessions for interactive CLIs (python, node, gdb, etc.)
 
 #### Projects Built with AI
 

--- a/configs/amp/settings.json
+++ b/configs/amp/settings.json
@@ -1,62 +1,77 @@
 {
 	"amp.dangerouslyAllowAll": true,
 	"amp.experimental.autoHandoff": {
-		"context": 90
-	},
+    "context": 90
+  },
 	"amp.mcpServers": {
-		"context7": {
-			"url": "https://mcp.context7.com/mcp"
-		},
-		"sequential-thinking": {
-			"command": "npx",
-			"args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
-		},
-		"qmd": {
-			"command": "qmd",
-			"args": ["mcp"]
-		},
-		"fff": {
-			"command": "fff-mcp",
-			"args": []
-		},
-		"react-grab-mcp": {
-			"command": "npx",
-			"args": ["-y", "@react-grab/mcp", "--stdio"]
-		},
-		"logpilot": {
-			"command": "logpilot",
-			"args": ["mcp-server"]
-		},
-		"agentmemory": {
-			"command": "npx",
-			"args": ["-y", "@agentmemory/mcp"]
-		},
-		"sem": {
-			"command": "sem-mcp",
-			"args": []
-		}
-	},
+    "context7": {
+      "url": "https://mcp.context7.com/mcp"
+    },
+    "sequential-thinking": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking"
+      ]
+    },
+    "qmd": {
+      "command": "qmd",
+      "args": [
+        "mcp"
+      ]
+    },
+    "fff": {
+      "command": "fff-mcp",
+      "args": []
+    },
+    "react-grab-mcp": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@react-grab/mcp",
+        "--stdio"
+      ]
+    },
+    "logpilot": {
+      "command": "logpilot",
+      "args": [
+        "mcp-server"
+      ]
+    },
+    "agentmemory": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@agentmemory/mcp"
+      ]
+    },
+    "sem": {
+      "command": "sem-mcp",
+      "args": []
+    }
+  },
 	"amp.terminal.theme": "kanagawa",
 	"amp.terminal.customThemes": {
-		"kanagawa": {
-			"background": "#1F1F28",
-			"foreground": "#DCD7BA",
-			"black": "#090618",
-			"red": "#C34043",
-			"green": "#76946A",
-			"yellow": "#C0A36E",
-			"blue": "#7E9CD8",
-			"magenta": "#957FB8",
-			"cyan": "#6A9589",
-			"white": "#C8C093",
-			"brightBlack": "#727169",
-			"brightRed": "#E82424",
-			"brightGreen": "#98BB6C",
-			"brightYellow": "#E6C384",
-			"brightBlue": "#7FB4CA",
-			"brightMagenta": "#938AA9",
-			"brightCyan": "#7AA89F",
-			"brightWhite": "#DCD7BA"
-		}
-	}
+    "kanagawa": {
+      "background": "#1F1F28",
+      "foreground": "#DCD7BA",
+      "black": "#090618",
+      "red": "#C34043",
+      "green": "#76946A",
+      "yellow": "#C0A36E",
+      "blue": "#7E9CD8",
+      "magenta": "#957FB8",
+      "cyan": "#6A9589",
+      "white": "#C8C093",
+      "brightBlack": "#727169",
+      "brightRed": "#E82424",
+      "brightGreen": "#98BB6C",
+      "brightYellow": "#E6C384",
+      "brightBlue": "#7FB4CA",
+      "brightMagenta": "#938AA9",
+      "brightCyan": "#7AA89F",
+      "brightWhite": "#DCD7BA"
+    }
+  },
+  "amp.gauge": "cost"
 }

--- a/configs/cline/models.json
+++ b/configs/cline/models.json
@@ -1,22 +1,46 @@
 {
-	"version": 1,
-	"providers": {
-		"firepass": {
-			"provider": {
-				"name": "Firework - Firepass",
-				"baseUrl": "https://api.fireworks.ai/inference/v1",
-				"defaultModelId": "accounts/fireworks/routers/kimi-k2p5-turbo",
-				"capabilities": ["streaming", "tools", "vision"]
-			},
-			"models": {
-				"accounts/fireworks/routers/kimi-k2p5-turbo": {
-					"id": "accounts/fireworks/routers/kimi-k2p5-turbo",
-					"name": "accounts/fireworks/routers/kimi-k2p5-turbo",
-					"supportsVision": true,
-					"supportsAttachments": true,
-					"supportsReasoning": false
-				}
-			}
-		}
-	}
+  "version": 1,
+  "providers": {
+    "firepass": {
+      "provider": {
+        "name": "Firework - Firepass",
+        "baseUrl": "https://api.fireworks.ai/inference/v1",
+        "defaultModelId": "accounts/fireworks/routers/kimi-k2p5-turbo",
+        "capabilities": [
+          "streaming",
+          "tools",
+          "vision"
+        ]
+      },
+      "models": {
+        "accounts/fireworks/routers/kimi-k2p5-turbo": {
+          "id": "accounts/fireworks/routers/kimi-k2p5-turbo",
+          "name": "accounts/fireworks/routers/kimi-k2p5-turbo",
+          "supportsVision": true,
+          "supportsAttachments": true,
+          "supportsReasoning": false
+        }
+      }
+    },
+    "openai-compatible": {
+      "provider": {
+        "name": "OpenAI Compatible",
+        "baseUrl": "http://127.0.0.1:8787/v1",
+        "defaultModelId": "composer-2.5"
+      },
+      "models": {
+        "composer-2.5": {
+          "id": "composer-2.5",
+          "name": "composer-2.5",
+          "contextWindow": 128000,
+          "maxInputTokens": 128000,
+          "capabilities": [
+            "streaming",
+            "tools",
+            "images"
+          ]
+        }
+      }
+    }
+  }
 }

--- a/configs/kiro/mcp.json
+++ b/configs/kiro/mcp.json
@@ -1,16 +1,33 @@
 {
   "mcpServers": {
+    "fetch": {
+      "command": "uvx",
+      "args": [
+        "mcp-server-fetch"
+      ],
+      "env": {},
+      "disabled": true,
+      "autoApprove": []
+    },
     "context7": {
       "command": "npx",
-      "args": ["-y", "@upstash/context7-mcp@latest"]
+      "args": [
+        "-y",
+        "@upstash/context7-mcp@latest"
+      ]
     },
     "sequential-thinking": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-sequential-thinking@latest"]
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking@latest"
+      ]
     },
     "qmd": {
       "command": "qmd",
-      "args": ["mcp"]
+      "args": [
+        "mcp"
+      ]
     },
     "fff": {
       "type": "stdio",
@@ -19,15 +36,24 @@
     },
     "react-grab-mcp": {
       "command": "npx",
-      "args": ["-y", "@react-grab/mcp@latest", "--stdio"]
+      "args": [
+        "-y",
+        "@react-grab/mcp@latest",
+        "--stdio"
+      ]
     },
     "logpilot": {
       "command": "logpilot",
-      "args": ["mcp-server"]
+      "args": [
+        "mcp-server"
+      ]
     },
     "agentmemory": {
       "command": "npx",
-      "args": ["-y", "@agentmemory/mcp@latest"]
+      "args": [
+        "-y",
+        "@agentmemory/mcp@latest"
+      ]
     },
     "sem": {
       "command": "sem-mcp",

--- a/configs/opencode/opencode.json
+++ b/configs/opencode/opencode.json
@@ -1,165 +1,245 @@
 {
-	"$schema": "https://opencode.ai/config.json",
-	"agent": {
-		"build": {
-			"permission": {
-				"bash": {
-					"$HOME/.claude/skills/qmd-knowledge/scripts/record.sh": "allow",
-					"$HOME/.config/opencode/skills/qmd-knowledge/scripts/record.sh": "allow",
-					"git push": "ask",
-					"qmd": "allow",
-					"qmd get": "allow",
-					"qmd query": "allow",
-					"qmd search": "allow"
-				}
-			}
-		}
-	},
-	"default_agent": "plan",
-	"formatter": {
-		"biome": {
-			"command": ["biome", "check", "--write", "$FILE"],
-			"extensions": [".ts", ".tsx", ".js", ".jsx"]
-		},
-		"gofmt": {
-			"command": ["gofmt", "-w", "$FILE"],
-			"extensions": [".go"]
-		},
-		"prettier": {
-			"command": ["npx", "prettier", "--write", "$FILE"],
-			"extensions": [".md", ".mdx"]
-		},
-		"ruff": {
-			"command": ["ruff", "format", "$FILE"],
-			"extensions": [".py"]
-		},
-		"rustfmt": {
-			"command": ["rustfmt", "$FILE"],
-			"extensions": [".rs"]
-		},
-		"shfmt": {
-			"command": ["shfmt", "-w", "$FILE"],
-			"extensions": [".sh"]
-		},
-		"stylua": {
-			"command": ["stylua", "$FILE"],
-			"extensions": [".lua"]
-		}
-	},
-	"instructions": ["~/.ai-tools/best-practices.md", "~/.ai-tools/MEMORY.md", "~/.ai-tools/agent-memory.md"],
-	"mcp": {
-		"agentmemory": {
-			"command": ["npx", "-y", "@agentmemory/mcp"],
-			"enabled": true,
-			"environment": {
-				"AGENTMEMORY_SECRET": "${AGENTMEMORY_SECRET:-}",
-				"AGENTMEMORY_TOOLS": "${AGENTMEMORY_TOOLS:-all}",
-				"AGENTMEMORY_URL": "${AGENTMEMORY_URL:-http://localhost:3111}"
-			},
-			"type": "local"
-		},
-		"context7": {
-			"command": ["npx", "-y", "@upstash/context7-mcp@latest"],
-			"enabled": true,
-			"type": "local"
-		},
-		"fff": {
-			"command": ["fff-mcp"],
-			"enabled": true,
-			"type": "local"
-		},
-		"logpilot": {
-			"command": ["logpilot", "mcp-server"],
-			"enabled": true,
-			"type": "local"
-		},
-		"qmd": {
-			"command": ["qmd", "mcp"],
-			"enabled": true,
-			"type": "local"
-		},
-		"react-grab-mcp": {
-			"command": ["npx", "-y", "@react-grab/mcp", "--stdio"],
-			"enabled": true,
-			"type": "local"
-		},
-		"sem": {
-			"command": ["sem-mcp"],
-			"enabled": true,
-			"type": "local"
-		},
-		"sequential-thinking": {
-			"command": ["npx", "-y", "@modelcontextprotocol/server-sequential-thinking"],
-			"enabled": true,
-			"type": "local"
-		}
-	},
-	"model": "opencode/big-pickle",
-	"plugin": ["@plannotator/opencode@latest", "opencode-chrome-annotation@latest"],
-	"provider": {
-		"cursorapi": {
-			"models": {
-				"composer-2.5": {
-					"cost": {
-						"input": 0.5,
-						"output": 2.5
-					},
-					"limit": {
-						"context": 200000,
-						"output": 65536
-					},
-					"name": "Composer 2.5"
-				},
-				"composer-2.5-fast": {
-					"cost": {
-						"input": 3,
-						"output": 15
-					},
-					"limit": {
-						"context": 200000,
-						"output": 65536
-					},
-					"name": "Composer 2.5 Fast"
-				}
-			},
-			"name": "API for Cursor",
-			"npm": "@ai-sdk/openai-compatible",
-			"options": {
-				"apiKey": "cursor-local",
-				"baseURL": "http://127.0.0.1:8788/v1"
-			}
-		},
-		"llama.cpp": {
-			"models": {
-				"glm": {
-					"limit": {
-						"context": 32768,
-						"output": 16384
-					},
-					"name": "GLM-4.7-Flash (local)"
-				}
-			},
-			"name": "llama-server (local)",
-			"npm": "@ai-sdk/openai-compatible",
-			"options": {
-				"baseURL": "http://192.168.1.11:8000/v1"
-			}
-		},
-		"ollama": {
-			"models": {
-				"minimax-m2.5:cloud": {
-					"limit": {
-						"context": 204800,
-						"output": 128000
-					},
-					"name": "minimax-m2.5:cloud"
-				}
-			},
-			"name": "Ollama (local)",
-			"npm": "@ai-sdk/openai-compatible",
-			"options": {
-				"baseURL": "http://127.0.0.1:11434/v1"
-			}
-		}
-	}
+  "$schema" : "https://opencode.ai/config.json",
+  "agent" : {
+    "build" : {
+      "permission" : {
+        "bash" : {
+          "$HOME/.claude/skills/qmd-knowledge/scripts/record.sh" : "allow",
+          "$HOME/.config/opencode/skills/qmd-knowledge/scripts/record.sh" : "allow",
+          "git push" : "ask",
+          "qmd" : "allow",
+          "qmd get" : "allow",
+          "qmd query" : "allow",
+          "qmd search" : "allow"
+        }
+      }
+    }
+  },
+  "default_agent" : "plan",
+  "formatter" : {
+    "biome" : {
+      "command" : [
+        "biome",
+        "check",
+        "--write",
+        "$FILE"
+      ],
+      "extensions" : [
+        ".ts",
+        ".tsx",
+        ".js",
+        ".jsx"
+      ]
+    },
+    "gofmt" : {
+      "command" : [
+        "gofmt",
+        "-w",
+        "$FILE"
+      ],
+      "extensions" : [
+        ".go"
+      ]
+    },
+    "prettier" : {
+      "command" : [
+        "npx",
+        "prettier",
+        "--write",
+        "$FILE"
+      ],
+      "extensions" : [
+        ".md",
+        ".mdx"
+      ]
+    },
+    "ruff" : {
+      "command" : [
+        "ruff",
+        "format",
+        "$FILE"
+      ],
+      "extensions" : [
+        ".py"
+      ]
+    },
+    "rustfmt" : {
+      "command" : [
+        "rustfmt",
+        "$FILE"
+      ],
+      "extensions" : [
+        ".rs"
+      ]
+    },
+    "shfmt" : {
+      "command" : [
+        "shfmt",
+        "-w",
+        "$FILE"
+      ],
+      "extensions" : [
+        ".sh"
+      ]
+    },
+    "stylua" : {
+      "command" : [
+        "stylua",
+        "$FILE"
+      ],
+      "extensions" : [
+        ".lua"
+      ]
+    }
+  },
+  "instructions" : [
+    "~/.ai-tools/best-practices.md",
+    "~/.ai-tools/MEMORY.md",
+    "~/.ai-tools/agent-memory.md"
+  ],
+  "mcp" : {
+    "agentmemory" : {
+      "command" : [
+        "npx",
+        "-y",
+        "@agentmemory/mcp"
+      ],
+      "enabled" : true,
+      "environment" : {
+        "AGENTMEMORY_SECRET" : "${AGENTMEMORY_SECRET:-}",
+        "AGENTMEMORY_TOOLS" : "${AGENTMEMORY_TOOLS:-all}",
+        "AGENTMEMORY_URL" : "${AGENTMEMORY_URL:-http://localhost:3111}"
+      },
+      "type" : "local"
+    },
+    "context7" : {
+      "command" : [
+        "npx",
+        "-y",
+        "@upstash/context7-mcp@latest"
+      ],
+      "enabled" : true,
+      "type" : "local"
+    },
+    "fff" : {
+      "command" : [
+        "fff-mcp"
+      ],
+      "enabled" : true,
+      "type" : "local"
+    },
+    "logpilot" : {
+      "command" : [
+        "logpilot",
+        "mcp-server"
+      ],
+      "enabled" : true,
+      "type" : "local"
+    },
+    "qmd" : {
+      "command" : [
+        "qmd",
+        "mcp"
+      ],
+      "enabled" : true,
+      "type" : "local"
+    },
+    "react-grab-mcp" : {
+      "command" : [
+        "npx",
+        "-y",
+        "@react-grab/mcp",
+        "--stdio"
+      ],
+      "enabled" : true,
+      "type" : "local"
+    },
+    "sem" : {
+      "command" : [
+        "sem-mcp"
+      ],
+      "enabled" : true,
+      "type" : "local"
+    },
+    "sequential-thinking" : {
+      "command" : [
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking"
+      ],
+      "enabled" : true,
+      "type" : "local"
+    }
+  },
+  "model" : "opencode/big-pickle",
+  "plugin" : [
+    "@plannotator/opencode@latest",
+    "opencode-chrome-annotation@latest"
+  ],
+  "provider" : {
+    "cursorapi" : {
+      "models" : {
+        "composer-2.5" : {
+          "cost" : {
+            "input" : 0.5,
+            "output" : 2.5
+          },
+          "limit" : {
+            "context" : 200000,
+            "output" : 65536
+          },
+          "name" : "Composer 2.5"
+        },
+        "composer-2.5-fast" : {
+          "cost" : {
+            "input" : 3,
+            "output" : 15
+          },
+          "limit" : {
+            "context" : 200000,
+            "output" : 65536
+          },
+          "name" : "Composer 2.5 Fast"
+        }
+      },
+      "name" : "API for Cursor",
+      "npm" : "@ai-sdk/openai-compatible",
+      "options" : {
+        "apiKey" : "cursor-local",
+        "baseURL" : "http://127.0.0.1:8788/v1"
+      }
+    },
+    "llama.cpp" : {
+      "models" : {
+        "glm" : {
+          "limit" : {
+            "context" : 32768,
+            "output" : 16384
+          },
+          "name" : "GLM-4.7-Flash (local)"
+        }
+      },
+      "name" : "llama-server (local)",
+      "npm" : "@ai-sdk/openai-compatible",
+      "options" : {
+        "baseURL" : "http://192.168.1.11:8000/v1"
+      }
+    },
+    "ollama" : {
+      "models" : {
+        "minimax-m2.5:cloud" : {
+          "limit" : {
+            "context" : 204800,
+            "output" : 128000
+          },
+          "name" : "minimax-m2.5:cloud"
+        }
+      },
+      "name" : "Ollama (local)",
+      "npm" : "@ai-sdk/openai-compatible",
+      "options" : {
+        "baseURL" : "http://127.0.0.1:11434/v1"
+      }
+    }
+  }
 }

--- a/configs/qodercli/AGENTS.md
+++ b/configs/qodercli/AGENTS.md
@@ -42,4 +42,3 @@ See @~/.ai-tools/best-practices.md for full details.
 - Keep your code modular and reusable. Avoid tight coupling and excessive dependencies.
 - Run typecheck, lint and biome on js/ts file changes after finish.
 - Prefer to use Bun to run scripts if possible, otherwise use tsx to run ts files.
-

--- a/skills/adr/SKILL.md
+++ b/skills/adr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adr
-description: Manages Architecture Decision Records (ADR) for tracking important architectural decisions
+description: Manage Architecture Decision Records for tracking important architectural decisions. Use when creating, listing, searching, viewing, or superseding ADRs.
 license: MIT
 compatibility: cline, claude, opencode, amp, codex, gemini, cursor, pi
 hint: Use when managing architecture decisions, creating ADRs, or tracking architectural choices
@@ -26,7 +26,6 @@ Provides a unified interface for managing Architecture Decision Records.
 - **list** - List all ADRs in the project
 - **search <TERM>** - Search ADRs by content
 - **view <NUMBER>** - View specific ADR
-- **help** - Show this help
 
 ## What are ADRs?
 

--- a/skills/adr/SKILL.md
+++ b/skills/adr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: adr
-description: Manage Architecture Decision Records for tracking important architectural decisions. Use when creating, listing, searching, viewing, or superseding ADRs.
+description: Manages Architecture Decision Records for tracking important architectural decisions. Use when creating, listing, searching, viewing, or superseding ADRs.
 license: MIT
 compatibility: cline, claude, opencode, amp, codex, gemini, cursor, pi
 hint: Use when managing architecture decisions, creating ADRs, or tracking architectural choices

--- a/skills/codemap/SKILL.md
+++ b/skills/codemap/SKILL.md
@@ -10,6 +10,8 @@ metadata:
   workflow: codebase-mapping
 ---
 
+# Codemap
+
 ## What I do
 
 Analyze your entire codebase and create 7 comprehensive documentation files in `.planning/codebase/`:
@@ -282,14 +284,6 @@ _finder -t f "\.ts$" -e "\.tsx$" src/ 2>/dev/null | xargs wc -l 2>/dev/null | so
 4. **Be thorough** - Read actual files, don't guess
 5. **Return only confirmation** - Response should be ~10 lines with file paths and line counts
 6. **Don't commit** - The orchestrator handles git operations
-
-## Benefits
-
-- **Fast**: Parallel exploration reduces total time
-- **Fresh context**: Each agent starts clean, no token contamination
-- **Minimal context transfer**: Agents write directly, orchestrator only receives confirmations
-- **Comprehensive**: 7 structured documents cover all aspects of the codebase
-- **Reusable**: Documents serve as reference for future planning and development
 
 ## Inspiration
 

--- a/skills/draft-pull-request/SKILL.md
+++ b/skills/draft-pull-request/SKILL.md
@@ -66,7 +66,7 @@ Write a structured description following the **What / Why / How** template:
 - [ ] No breaking changes (or breaking changes documented above)
 ```
 
-### 4. Create the draft PR with gh CLI
+### 3. Create the draft PR with gh CLI
 
 ```bash
 gh pr create \

--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: llm-wiki
+description: Build and maintain a persistent, LLM-driven knowledge wiki from raw sources. Based on Karpathy's LLM Wiki pattern — incremental ingestion, compounding synthesis, and zero-maintenance cross-referencing.
+license: MIT
+compatibility: cline, claude, opencode, amp, codex, gemini, cursor, pi
+hint: Use when building a personal knowledge base, researching a topic over time, or maintaining a structured wiki from raw documents
+user-invocable: true
+metadata:
+  audience: all
+  workflow: knowledge-management
+---
+
+# LLM Wiki
+
+Build and maintain a persistent, compounding knowledge wiki from raw sources.
+
+Inspired by [Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f): the LLM incrementally builds and maintains a structured, interlinked collection of markdown files — so knowledge compounds across sessions instead of being re-derived from scratch on every query.
+
+## Usage
+
+`/llm-wiki <ACTION> [ARGUMENTS]`
+
+## Actions
+
+- **init [DIRECTORY]** - Initialize a new LLM Wiki in the given directory (default: `wiki/`)
+- **ingest <SOURCE>** - Process a new source file and integrate it into the wiki
+- **query <QUESTION>** - Answer a question using the wiki as the knowledge base
+- **lint** - Health-check the wiki for contradictions, orphan pages, and stale content
+- **status** - Show a summary of the wiki's current state
+- **help** - Show this help
+
+---
+
+## The Core Idea
+
+Most LLM+document workflows are stateless: documents are retrieved at query time and the LLM re-derives synthesis from scratch on every question. **Nothing compounds.**
+
+The LLM Wiki pattern is different. The LLM **incrementally builds and maintains a persistent wiki** — a structured directory of markdown files that sits between you and your raw sources. When you add a new source:
+
+- The LLM reads it, extracts key information, and **integrates it into the existing wiki**
+- It updates entity pages, revises topic summaries, flags contradictions, strengthens cross-references
+- The synthesis is compiled once and kept current — not re-derived on every query
+
+**The wiki is a persistent, compounding artifact.** Cross-references are already there. Contradictions have already been flagged. Synthesis already reflects everything you've read.
+
+You never write the wiki yourself — the LLM writes and maintains all of it. You curate sources, explore, and ask good questions.
+
+> **Obsidian = IDE; LLM = programmer; Wiki = codebase.**
+
+---
+
+## Architecture
+
+A wiki has three layers:
+
+```
+your-wiki/
+├── raw/           # Immutable source documents (you add these)
+│   ├── article-1.md
+│   ├── paper-2.pdf
+│   └── assets/    # Downloaded images
+├── wiki/          # LLM-generated and maintained pages (LLM writes these)
+│   ├── index.md   # Catalog of all pages with one-line summaries
+│   ├── log.md     # Append-only chronological record of operations
+│   ├── overview.md
+│   ├── entities/  # Pages for people, places, organizations
+│   ├── concepts/  # Pages for ideas, topics, themes
+│   └── sources/   # Summary pages per source
+└── CLAUDE.md      # Schema: wiki conventions and LLM workflow instructions
+```
+
+**raw/** — Your curated source documents. Immutable — the LLM reads from them but never modifies them.
+
+**wiki/** — LLM-generated markdown files. Summaries, entity pages, concept pages, comparisons, synthesis. The LLM owns this layer entirely.
+
+**CLAUDE.md / AGENTS.md** — The schema that tells the LLM how the wiki is structured, what conventions to follow, and what workflows to run during ingest, query, and lint. Co-evolve this with the LLM over time.
+
+Templates for all of these are available in `$SKILL_PATH/templates/`.
+
+---
+
+## Operations
+
+### For "init [DIRECTORY]":
+
+1. Create the directory structure (`raw/`, `wiki/`, `wiki/entities/`, `wiki/concepts/`, `wiki/sources/`)
+2. Copy `$SKILL_PATH/templates/schema.md` to `CLAUDE.md` (or `AGENTS.md`) as the starting schema
+3. Create `wiki/index.md` from `$SKILL_PATH/templates/index.md`
+4. Create `wiki/log.md` from `$SKILL_PATH/templates/log.md`
+5. Create a starter `wiki/overview.md` summarizing the wiki's domain and purpose
+6. Print next steps: add sources to `raw/`, then run `/llm-wiki ingest <file>`
+
+### For "ingest <SOURCE>":
+
+1. Read the source file from `raw/<SOURCE>`
+2. Discuss key takeaways — what's new, what's important, what's surprising
+3. Write a source summary page in `wiki/sources/<slug>.md`
+4. Update `wiki/overview.md` if the source changes the big picture
+5. Create or update entity pages (`wiki/entities/`) for key people, places, organizations
+6. Create or update concept pages (`wiki/concepts/`) for key ideas and themes
+7. Flag any contradictions with existing wiki content (note them on the affected pages)
+8. Update `wiki/index.md` with all new/modified pages
+9. Append an entry to `wiki/log.md`: `## [YYYY-MM-DD] ingest | <Source Title>`
+
+A single source typically touches 5–15 wiki pages. Stay involved — read the summaries, check the updates, and guide the LLM on emphasis.
+
+### For "query <QUESTION>":
+
+1. Read `wiki/index.md` to identify the most relevant pages
+2. Read the relevant pages in full
+3. Synthesize an answer with citations to specific wiki pages
+4. If the answer is a valuable synthesis (comparison, analysis, new connection), offer to file it as a new wiki page
+5. If filed, update `wiki/index.md` and append to `wiki/log.md`
+
+Good answers compound in the wiki just like ingested sources do.
+
+### For "lint":
+
+Scan the entire wiki and report on:
+
+- **Contradictions**: Claims on different pages that conflict with each other
+- **Stale content**: Pages superseded by newer ingested material
+- **Orphan pages**: Pages with no inbound links from other wiki pages
+- **Missing pages**: Important concepts mentioned across multiple pages but lacking their own page
+- **Broken references**: Links to pages that don't exist
+- **Data gaps**: Areas where a targeted web search or new source could meaningfully fill in missing knowledge
+
+Suggest new questions to investigate and new sources to look for. Optionally fix issues in place.
+
+### For "status":
+
+Report:
+
+- Total source count in `raw/`
+- Total wiki page count
+- Recent entries in `wiki/log.md` (last 10)
+- Any obvious health issues (orphan pages, missing index entries)
+
+---
+
+## Index and Log
+
+Two special files help navigate the wiki as it grows:
+
+**wiki/index.md** — Content-oriented catalog. Every page listed with a link, one-line summary, and optional metadata (date added, source count). Organized by category. Updated on every ingest. The LLM reads this first when answering queries to find relevant pages.
+
+**wiki/log.md** — Chronological, append-only record. Each entry starts with `## [YYYY-MM-DD] <operation> | <title>`. Parseable with standard tools:
+
+```bash
+# Last 5 operations
+grep "^## \[" wiki/log.md | tail -5
+
+# All ingests
+grep "^## \[.*\] ingest" wiki/log.md
+
+# All queries
+grep "^## \[.*\] query" wiki/log.md
+```
+
+---
+
+## Optional: Search with qmd
+
+At small scale the index file is enough. As the wiki grows, add proper search using [qmd](https://github.com/tobi/qmd) — local hybrid BM25/vector search with an MCP server:
+
+```bash
+# Install
+bun install -g @tobilu/qmd
+
+# Add your wiki as a collection
+qmd collection add ./wiki --name my-wiki
+qmd embed
+
+# Search from CLI
+qmd query "how does X relate to Y" -c my-wiki
+
+# Or use the MCP server for native tool access in Claude/OpenCode
+```
+
+---
+
+## Tips
+
+- **Obsidian Web Clipper**: Browser extension that converts web articles to clean markdown — ideal for quickly adding sources to `raw/`.
+- **Obsidian graph view**: Best way to see the shape of your wiki — which pages are hubs, which are orphans.
+- **Download images locally**: In Obsidian → Settings → Files and links, set attachment folder to `raw/assets/`. Use "Download attachments for current file" (bind to a hotkey) after clipping.
+- **Marp slides**: Ask the LLM to generate a Marp slide deck from wiki content for presentations.
+- **Version control**: The wiki is just a git repo of markdown files — you get history, branching, and collaboration for free.
+- **Ingest one at a time**: Stay involved during ingestion. Read the summaries, check the updates, guide emphasis. You can batch-ingest with less supervision, but you'll get more value staying in the loop.
+- **File good answers**: Valuable query results (comparisons, analyses, new connections) should be filed back as wiki pages. Your explorations compound the knowledge base.
+
+---
+
+## Use Cases
+
+- **Personal**: Tracking goals, health, self-improvement — filing journal entries, articles, podcast notes, building a structured picture over time
+- **Research**: Going deep on a topic — reading papers and incrementally building a comprehensive wiki with an evolving thesis
+- **Reading a book**: Filing each chapter, building pages for characters, themes, plot threads. By the end you have a rich companion wiki.
+- **Business/team**: Internal wiki fed by meeting transcripts, project documents, Slack threads — maintained by LLMs, reviewed by humans
+- **Competitive analysis, due diligence, trip planning, course notes, hobby deep-dives** — anything where knowledge accumulates over time

--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -42,6 +42,7 @@ your-wiki/
 │   ├── overview.md
 │   ├── entities/  # People, places, organizations
 │   ├── concepts/  # Ideas, topics, themes
+│   ├── synthesis/ # Filed query answers and analyses
 │   └── sources/   # One summary page per source
 └── CLAUDE.md      # Schema: wiki conventions and per-operation workflows
 ```
@@ -52,14 +53,14 @@ Templates for all three layers are in `$SKILL_PATH/templates/`.
 
 ## For "init [DIRECTORY]":
 
-1. Create the directory structure: `raw/`, `wiki/`, `wiki/entities/`, `wiki/concepts/`, `wiki/sources/`
+1. Create the directory structure: `raw/`, `wiki/`, `wiki/entities/`, `wiki/concepts/`, `wiki/synthesis/`, `wiki/sources/`
 2. Copy `$SKILL_PATH/templates/schema.md` to `CLAUDE.md` (or `AGENTS.md`)
 3. Create `wiki/index.md` from `$SKILL_PATH/templates/index.md`
 4. Create `wiki/log.md` from `$SKILL_PATH/templates/log.md`
 5. Create a starter `wiki/overview.md` stating the wiki's domain and purpose
 6. Tell the user to add sources to `raw/` and run `/llm-wiki ingest <file>` next
 
-**Done when:** all five files and directories exist and the user has been told the next step.
+**Done when:** `raw/`, `wiki/`, `wiki/entities/`, `wiki/concepts/`, `wiki/synthesis/`, `wiki/sources/`, `CLAUDE.md` (or `AGENTS.md`), `wiki/index.md`, `wiki/log.md`, and `wiki/overview.md` exist, and the user has been told the next step.
 
 ---
 
@@ -83,7 +84,7 @@ Templates for all three layers are in `$SKILL_PATH/templates/`.
 1. Read `wiki/index.md` to identify the most relevant pages
 2. Read those pages in full
 3. Synthesize an answer with citations to specific wiki pages
-4. If the answer is a valuable synthesis (comparison, analysis, discovered connection), offer to file it as a new wiki page; if filed, update `wiki/index.md` and append to `wiki/log.md`
+4. If the answer is a valuable synthesis (comparison, analysis, discovered connection), offer to file it as a new wiki page under `wiki/synthesis/`; if filed, update `wiki/index.md` and append to `wiki/log.md`
 
 **Done when:** the question is answered with citations, and any filing decision (page created or skipped) is resolved.
 

--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -22,7 +22,7 @@ Based on [Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf5
 
 ## Actions
 
-- **init [DIRECTORY]** - Initialize a new wiki (default: `wiki/`)
+- **init [DIRECTORY]** - Initialize a new wiki (default: `.` — current directory)
 - **ingest <SOURCE>** - Process a source file and integrate it into the wiki
 - **query <QUESTION>** - Answer a question using the wiki as the knowledge base
 - **lint** - Health-check the wiki for contradictions, orphan pages, and stale content
@@ -149,4 +149,3 @@ qmd query "how does X relate to Y" -c my-wiki
 - **File good answers**: valuable query results (comparisons, analyses, new connections) should become wiki pages — explorations compound the knowledge base just like ingested sources do.
 - **Ingest one source at a time** — read the summaries, check the updates, guide emphasis. You get more value staying in the loop than batch-ingesting unattended.
 - The wiki is a git repo of markdown files — version history and collaboration come free.
-

--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: llm-wiki
-description: Build and maintain a persistent, LLM-driven knowledge wiki from raw sources. Based on Karpathy's LLM Wiki pattern — incremental ingestion, compounding synthesis, and zero-maintenance cross-referencing.
+description: Build and maintain a persistent, compounding knowledge wiki from raw sources. Use when the user wants to create a knowledge base, ingest documents into a wiki, query a wiki, health-check a wiki, or set up Karpathy's LLM Wiki pattern.
 license: MIT
 compatibility: cline, claude, opencode, amp, codex, gemini, cursor, pi
 hint: Use when building a personal knowledge base, researching a topic over time, or maintaining a structured wiki from raw documents
@@ -14,7 +14,7 @@ metadata:
 
 Build and maintain a persistent, compounding knowledge wiki from raw sources.
 
-Inspired by [Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f): the LLM incrementally builds and maintains a structured, interlinked collection of markdown files — so knowledge compounds across sessions instead of being re-derived from scratch on every query.
+Based on [Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f): the LLM incrementally integrates each new source into a structured wiki of markdown files — updating entity pages, flagging contradictions, strengthening cross-references. Synthesis is compiled once and kept current, not re-derived on every query.
 
 ## Usage
 
@@ -22,179 +22,131 @@ Inspired by [Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6
 
 ## Actions
 
-- **init [DIRECTORY]** - Initialize a new LLM Wiki in the given directory (default: `wiki/`)
-- **ingest <SOURCE>** - Process a new source file and integrate it into the wiki
+- **init [DIRECTORY]** - Initialize a new wiki (default: `wiki/`)
+- **ingest <SOURCE>** - Process a source file and integrate it into the wiki
 - **query <QUESTION>** - Answer a question using the wiki as the knowledge base
 - **lint** - Health-check the wiki for contradictions, orphan pages, and stale content
 - **status** - Show a summary of the wiki's current state
-- **help** - Show this help
-
----
-
-## The Core Idea
-
-Most LLM+document workflows are stateless: documents are retrieved at query time and the LLM re-derives synthesis from scratch on every question. **Nothing compounds.**
-
-The LLM Wiki pattern is different. The LLM **incrementally builds and maintains a persistent wiki** — a structured directory of markdown files that sits between you and your raw sources. When you add a new source:
-
-- The LLM reads it, extracts key information, and **integrates it into the existing wiki**
-- It updates entity pages, revises topic summaries, flags contradictions, strengthens cross-references
-- The synthesis is compiled once and kept current — not re-derived on every query
-
-**The wiki is a persistent, compounding artifact.** Cross-references are already there. Contradictions have already been flagged. Synthesis already reflects everything you've read.
-
-You never write the wiki yourself — the LLM writes and maintains all of it. You curate sources, explore, and ask good questions.
-
-> **Obsidian = IDE; LLM = programmer; Wiki = codebase.**
 
 ---
 
 ## Architecture
 
-A wiki has three layers:
-
 ```
 your-wiki/
-├── raw/           # Immutable source documents (you add these)
-│   ├── article-1.md
-│   ├── paper-2.pdf
-│   └── assets/    # Downloaded images
-├── wiki/          # LLM-generated and maintained pages (LLM writes these)
+├── raw/           # Immutable source documents — you add, LLM never modifies
+│   └── assets/    # Downloaded images referenced by sources
+├── wiki/          # LLM-generated and maintained pages
 │   ├── index.md   # Catalog of all pages with one-line summaries
-│   ├── log.md     # Append-only chronological record of operations
+│   ├── log.md     # Append-only record of all operations
 │   ├── overview.md
-│   ├── entities/  # Pages for people, places, organizations
-│   ├── concepts/  # Pages for ideas, topics, themes
-│   └── sources/   # Summary pages per source
-└── CLAUDE.md      # Schema: wiki conventions and LLM workflow instructions
+│   ├── entities/  # People, places, organizations
+│   ├── concepts/  # Ideas, topics, themes
+│   └── sources/   # One summary page per source
+└── CLAUDE.md      # Schema: wiki conventions and per-operation workflows
 ```
 
-**raw/** — Your curated source documents. Immutable — the LLM reads from them but never modifies them.
-
-**wiki/** — LLM-generated markdown files. Summaries, entity pages, concept pages, comparisons, synthesis. The LLM owns this layer entirely.
-
-**CLAUDE.md / AGENTS.md** — The schema that tells the LLM how the wiki is structured, what conventions to follow, and what workflows to run during ingest, query, and lint. Co-evolve this with the LLM over time.
-
-Templates for all of these are available in `$SKILL_PATH/templates/`.
+Templates for all three layers are in `$SKILL_PATH/templates/`.
 
 ---
 
-## Operations
+## For "init [DIRECTORY]":
 
-### For "init [DIRECTORY]":
-
-1. Create the directory structure (`raw/`, `wiki/`, `wiki/entities/`, `wiki/concepts/`, `wiki/sources/`)
-2. Copy `$SKILL_PATH/templates/schema.md` to `CLAUDE.md` (or `AGENTS.md`) as the starting schema
+1. Create the directory structure: `raw/`, `wiki/`, `wiki/entities/`, `wiki/concepts/`, `wiki/sources/`
+2. Copy `$SKILL_PATH/templates/schema.md` to `CLAUDE.md` (or `AGENTS.md`)
 3. Create `wiki/index.md` from `$SKILL_PATH/templates/index.md`
 4. Create `wiki/log.md` from `$SKILL_PATH/templates/log.md`
-5. Create a starter `wiki/overview.md` summarizing the wiki's domain and purpose
-6. Print next steps: add sources to `raw/`, then run `/llm-wiki ingest <file>`
+5. Create a starter `wiki/overview.md` stating the wiki's domain and purpose
+6. Tell the user to add sources to `raw/` and run `/llm-wiki ingest <file>` next
 
-### For "ingest <SOURCE>":
-
-1. Read the source file from `raw/<SOURCE>`
-2. Discuss key takeaways — what's new, what's important, what's surprising
-3. Write a source summary page in `wiki/sources/<slug>.md`
-4. Update `wiki/overview.md` if the source changes the big picture
-5. Create or update entity pages (`wiki/entities/`) for key people, places, organizations
-6. Create or update concept pages (`wiki/concepts/`) for key ideas and themes
-7. Flag any contradictions with existing wiki content (note them on the affected pages)
-8. Update `wiki/index.md` with all new/modified pages
-9. Append an entry to `wiki/log.md`: `## [YYYY-MM-DD] ingest | <Source Title>`
-
-A single source typically touches 5–15 wiki pages. Stay involved — read the summaries, check the updates, and guide the LLM on emphasis.
-
-### For "query <QUESTION>":
-
-1. Read `wiki/index.md` to identify the most relevant pages
-2. Read the relevant pages in full
-3. Synthesize an answer with citations to specific wiki pages
-4. If the answer is a valuable synthesis (comparison, analysis, new connection), offer to file it as a new wiki page
-5. If filed, update `wiki/index.md` and append to `wiki/log.md`
-
-Good answers compound in the wiki just like ingested sources do.
-
-### For "lint":
-
-Scan the entire wiki and report on:
-
-- **Contradictions**: Claims on different pages that conflict with each other
-- **Stale content**: Pages superseded by newer ingested material
-- **Orphan pages**: Pages with no inbound links from other wiki pages
-- **Missing pages**: Important concepts mentioned across multiple pages but lacking their own page
-- **Broken references**: Links to pages that don't exist
-- **Data gaps**: Areas where a targeted web search or new source could meaningfully fill in missing knowledge
-
-Suggest new questions to investigate and new sources to look for. Optionally fix issues in place.
-
-### For "status":
-
-Report:
-
-- Total source count in `raw/`
-- Total wiki page count
-- Recent entries in `wiki/log.md` (last 10)
-- Any obvious health issues (orphan pages, missing index entries)
+**Done when:** all five files and directories exist and the user has been told the next step.
 
 ---
 
-## Index and Log
+## For "ingest <SOURCE>":
 
-Two special files help navigate the wiki as it grows:
+1. Read the source file; share key takeaways and ask the user what to emphasize
+2. Create `wiki/sources/<slug>.md` with a structured summary
+3. Update `wiki/overview.md` if the source shifts the big picture
+4. Create or update entity pages in `wiki/entities/` for key people, places, organizations
+5. Create or update concept pages in `wiki/concepts/` for key ideas and themes
+6. Add a contradiction note on any existing page where this source conflicts with current content
+7. Update `wiki/index.md` — every new or modified page must appear with a one-line summary
+8. Append to `wiki/log.md`: `## [YYYY-MM-DD] ingest | <Source Title>`
 
-**wiki/index.md** — Content-oriented catalog. Every page listed with a link, one-line summary, and optional metadata (date added, source count). Organized by category. Updated on every ingest. The LLM reads this first when answering queries to find relevant pages.
+**Done when:** every affected page is updated, every new or changed page appears in `index.md`, and the log entry is appended. A single ingest typically touches 5–15 pages.
 
-**wiki/log.md** — Chronological, append-only record. Each entry starts with `## [YYYY-MM-DD] <operation> | <title>`. Parseable with standard tools:
+---
+
+## For "query <QUESTION>":
+
+1. Read `wiki/index.md` to identify the most relevant pages
+2. Read those pages in full
+3. Synthesize an answer with citations to specific wiki pages
+4. If the answer is a valuable synthesis (comparison, analysis, discovered connection), offer to file it as a new wiki page; if filed, update `wiki/index.md` and append to `wiki/log.md`
+
+**Done when:** the question is answered with citations, and any filing decision (page created or skipped) is resolved.
+
+---
+
+## For "lint":
+
+Scan the entire wiki and report on each of the following:
+
+- **Contradictions** — conflicting claims across pages
+- **Stale content** — pages superseded by newer ingested material
+- **Orphan pages** — pages with no inbound links
+- **Missing pages** — concepts mentioned on multiple pages but lacking their own page
+- **Broken links** — `[[Page Name]]` links pointing to non-existent pages
+- **Data gaps** — areas a targeted source or web search could fill
+
+Suggest new questions and sources. Ask before making any fixes.
+
+Append to `wiki/log.md`: `## [YYYY-MM-DD] lint | health check`
+
+**Done when:** all six issue types are checked and reported, suggestions are given, and the log entry is appended.
+
+---
+
+## For "status":
+
+Report: source count in `raw/`, wiki page count, last 10 entries in `wiki/log.md`, and any obvious health issues (orphan pages, missing index entries).
+
+**Done when:** all four items are reported.
+
+---
+
+## Index and log
+
+**wiki/index.md** — content catalog, updated on every ingest. Every page with a link and one-line summary, organized by category. The LLM reads this first when answering queries.
+
+**wiki/log.md** — append-only operation log. Entry format: `## [YYYY-MM-DD] <operation> | <title>`. Grep-parseable:
 
 ```bash
-# Last 5 operations
-grep "^## \[" wiki/log.md | tail -5
-
-# All ingests
-grep "^## \[.*\] ingest" wiki/log.md
-
-# All queries
-grep "^## \[.*\] query" wiki/log.md
+grep "^## \[" wiki/log.md | tail -5          # last 5 operations
+grep "^## \[.*\] ingest" wiki/log.md          # all ingests
+grep "^## \[.*\] query" wiki/log.md           # all queries
 ```
 
 ---
 
-## Optional: Search with qmd
+## Optional: qmd search
 
-At small scale the index file is enough. As the wiki grows, add proper search using [qmd](https://github.com/tobi/qmd) — local hybrid BM25/vector search with an MCP server:
+For larger wikis, add [qmd](https://github.com/tobi/qmd) — local hybrid BM25/vector search with an MCP server:
 
 ```bash
-# Install
 bun install -g @tobilu/qmd
-
-# Add your wiki as a collection
 qmd collection add ./wiki --name my-wiki
 qmd embed
-
-# Search from CLI
 qmd query "how does X relate to Y" -c my-wiki
-
-# Or use the MCP server for native tool access in Claude/OpenCode
 ```
 
 ---
 
 ## Tips
 
-- **Obsidian Web Clipper**: Browser extension that converts web articles to clean markdown — ideal for quickly adding sources to `raw/`.
-- **Obsidian graph view**: Best way to see the shape of your wiki — which pages are hubs, which are orphans.
-- **Download images locally**: In Obsidian → Settings → Files and links, set attachment folder to `raw/assets/`. Use "Download attachments for current file" (bind to a hotkey) after clipping.
-- **Marp slides**: Ask the LLM to generate a Marp slide deck from wiki content for presentations.
-- **Version control**: The wiki is just a git repo of markdown files — you get history, branching, and collaboration for free.
-- **Ingest one at a time**: Stay involved during ingestion. Read the summaries, check the updates, guide emphasis. You can batch-ingest with less supervision, but you'll get more value staying in the loop.
-- **File good answers**: Valuable query results (comparisons, analyses, new connections) should be filed back as wiki pages. Your explorations compound the knowledge base.
+- **Obsidian Web Clipper** converts web articles to markdown — fast source collection for `raw/`.
+- **File good answers**: valuable query results (comparisons, analyses, new connections) should become wiki pages — explorations compound the knowledge base just like ingested sources do.
+- **Ingest one source at a time** — read the summaries, check the updates, guide emphasis. You get more value staying in the loop than batch-ingesting unattended.
+- The wiki is a git repo of markdown files — version history and collaboration come free.
 
----
-
-## Use Cases
-
-- **Personal**: Tracking goals, health, self-improvement — filing journal entries, articles, podcast notes, building a structured picture over time
-- **Research**: Going deep on a topic — reading papers and incrementally building a comprehensive wiki with an evolving thesis
-- **Reading a book**: Filing each chapter, building pages for characters, themes, plot threads. By the end you have a rich companion wiki.
-- **Business/team**: Internal wiki fed by meeting transcripts, project documents, Slack threads — maintained by LLMs, reviewed by humans
-- **Competitive analysis, due diligence, trip planning, course notes, hobby deep-dives** — anything where knowledge accumulates over time

--- a/skills/llm-wiki/templates/index.md
+++ b/skills/llm-wiki/templates/index.md
@@ -1,0 +1,54 @@
+---
+title: "Wiki Index"
+updated: YYYY-MM-DD
+---
+
+# Wiki Index
+
+Catalog of all pages in this wiki. Updated on every ingest.
+
+---
+
+## Overview
+
+| Page | Summary |
+|------|---------|
+| [[overview]] | Big-picture synthesis of the entire wiki |
+
+---
+
+## Sources
+
+| Page | Summary | Date Ingested |
+|------|---------|---------------|
+| *(no sources yet)* | | |
+
+---
+
+## Entities
+
+| Page | Type | Summary |
+|------|------|---------|
+| *(no entity pages yet)* | | |
+
+---
+
+## Concepts
+
+| Page | Summary |
+|------|---------|
+| *(no concept pages yet)* | |
+
+---
+
+## Synthesis Pages
+
+Pages generated from queries and analyses (filed answers that compound the knowledge base).
+
+| Page | Summary | Date |
+|------|---------|------|
+| *(no synthesis pages yet)* | | |
+
+---
+
+*Last updated: YYYY-MM-DD*

--- a/skills/llm-wiki/templates/log.md
+++ b/skills/llm-wiki/templates/log.md
@@ -1,0 +1,31 @@
+# Wiki Log
+
+Append-only chronological record of all wiki operations.
+
+Format: `## [YYYY-MM-DD] <operation> | <title>`
+
+Operations: `ingest` | `query` | `lint` | `init`
+
+---
+
+## Useful queries
+
+```bash
+# Last 5 operations
+grep "^## \[" wiki/log.md | tail -5
+
+# All ingests
+grep "^## \[.*\] ingest" wiki/log.md
+
+# All queries
+grep "^## \[.*\] query" wiki/log.md
+
+# Count ingests
+grep -c "^## \[.*\] ingest" wiki/log.md
+```
+
+---
+
+## Log
+
+<!-- New entries are appended below, most recent at the bottom -->

--- a/skills/llm-wiki/templates/schema.md
+++ b/skills/llm-wiki/templates/schema.md
@@ -61,7 +61,7 @@ When a new source contradicts an existing claim, add a note block to the relevan
 
 ```markdown
 > [!NOTE] Contradiction (YYYY-MM-DD)
-> Source [Source Title] (wiki/sources/source-slug.md) contradicts the claim above: [brief description]. See both sources for context.
+> Source [[source-slug|Source Title]] contradicts the claim above: [brief description]. See both sources for context.
 ```
 
 ---
@@ -170,6 +170,6 @@ When I ask for a wiki health check:
 
 - **Voice**: Neutral, informative, encyclopedic — like Wikipedia
 - **Page length**: Aim for focused pages (300–800 words). Split if a page grows too large.
-- **Images**: Reference images from `raw/assets/` using relative paths: `![description](../raw/assets/image.png)`
+- **Images**: Reference images from `raw/assets/` using relative paths: `../../raw/assets/image.png` for nested pages (entities, concepts, sources), or `../raw/assets/image.png` for top-level pages (overview, index).
 - **Tables**: Use markdown tables for comparisons; Dataview for dynamic lists
-- **Citations**: Always cite which source supports a claim, linking to `wiki/sources/<slug>`
+- **Citations**: Always cite which source supports a claim, linking to the source page using Obsidian-style links: `[[slug]]`

--- a/skills/llm-wiki/templates/schema.md
+++ b/skills/llm-wiki/templates/schema.md
@@ -1,0 +1,175 @@
+# LLM Wiki — Schema
+
+This file tells the LLM how this wiki is structured, what conventions to follow, and what to do during ingestion, querying, and maintenance. Edit it as your domain and workflow evolve.
+
+## Domain
+
+<!-- Describe what this wiki is about. What topic or domain are you building knowledge about? -->
+
+**Domain:** [e.g., "AI research papers", "Personal health and fitness", "Project X competitive landscape"]
+
+**Purpose:** [e.g., "Build a structured, compounding knowledge base on X so I can synthesize insights across sources without re-reading everything."]
+
+**Owner:** [Your name or handle]
+
+**Started:** [YYYY-MM-DD]
+
+---
+
+## Directory Structure
+
+```
+raw/           # Immutable source documents — add files here, never delete
+  assets/      # Downloaded images referenced by sources
+wiki/          # LLM-generated and maintained pages
+  index.md     # Catalog of all pages (update on every ingest)
+  log.md       # Append-only operation log
+  overview.md  # Big-picture synthesis (update when fundamentals shift)
+  entities/    # Pages for key people, organizations, places
+  concepts/    # Pages for key ideas, themes, methodologies
+  sources/     # One summary page per ingested source
+CLAUDE.md or AGENTS.md  # This file (wiki schema)
+```
+
+---
+
+## Page Conventions
+
+### Frontmatter (optional but recommended)
+
+Add YAML frontmatter to wiki pages to enable Dataview queries in Obsidian:
+
+```yaml
+---
+title: "Page Title"
+type: concept | entity | source | synthesis | overview
+tags: [tag1, tag2]
+sources: 3          # Number of sources that informed this page
+updated: YYYY-MM-DD
+---
+```
+
+### Cross-references
+
+Always link to other wiki pages using Obsidian-style wiki links: `[[Page Name]]`
+
+When a concept or entity is first mentioned on a page, link it. Don't repeat the link on subsequent mentions on the same page.
+
+### Contradiction notes
+
+When a new source contradicts an existing claim, add a note block to the relevant page:
+
+```markdown
+> [!NOTE] Contradiction (YYYY-MM-DD)
+> Source [Source Title] (wiki/sources/source-slug.md) contradicts the claim above: [brief description]. See both sources for context.
+```
+
+---
+
+## Ingest Workflow
+
+When I give you a new source to ingest, follow this sequence:
+
+1. **Read and summarize**: Read the source carefully. Share key takeaways with me and ask if there's anything to emphasize or de-emphasize.
+2. **Source page**: Create `wiki/sources/<slug>.md` with a structured summary (see Source Page Template below).
+3. **Overview**: Update `wiki/overview.md` if the source meaningfully changes the big picture.
+4. **Entities**: Create or update pages in `wiki/entities/` for key people, organizations, and places mentioned.
+5. **Concepts**: Create or update pages in `wiki/concepts/` for key ideas and themes.
+6. **Contradiction check**: If any new information contradicts existing wiki content, add contradiction notes on the affected pages.
+7. **Index**: Update `wiki/index.md` — add new pages and update summaries for changed pages.
+8. **Log**: Append to `wiki/log.md`: `## [YYYY-MM-DD] ingest | <Source Title>`
+
+Typical ingest touches 5–15 pages. Be thorough with cross-references.
+
+### Source Page Template
+
+```markdown
+---
+title: "<Source Title>"
+type: source
+tags: []
+updated: YYYY-MM-DD
+---
+
+# <Source Title>
+
+**Author(s):** [Author names]
+**Published:** [Date or year]
+**Type:** [Article | Paper | Book chapter | Podcast | Video | ...]
+**Original:** [URL or file path in raw/]
+
+## Summary
+
+[2–4 paragraph summary of the source's main argument or content]
+
+## Key Points
+
+- [Key point 1]
+- [Key point 2]
+- [Key point 3]
+
+## Entities Mentioned
+
+- [[Entity 1]] — [brief note on their role in this source]
+- [[Entity 2]] — [brief note]
+
+## Concepts Introduced or Developed
+
+- [[Concept 1]] — [how this source treats this concept]
+- [[Concept 2]] — [how this source treats this concept]
+
+## Integration with Wiki
+
+[How does this source relate to, confirm, challenge, or extend what's already in the wiki?]
+
+## Notable Quotes
+
+> "[Direct quote from the source]" — [Author, page/timestamp]
+
+## Open Questions
+
+- [Question this source raises that isn't answered]
+- [Thread to pull on]
+```
+
+---
+
+## Query Workflow
+
+When I ask a question:
+
+1. Read `wiki/index.md` to identify the most relevant pages.
+2. Read those pages in full.
+3. Synthesize an answer with citations to specific wiki pages.
+4. If the answer is a valuable synthesis (comparison table, analysis, discovered connection), ask if I'd like to file it as a new page.
+5. If filing: create the page, update `wiki/index.md`, and append to `wiki/log.md`: `## [YYYY-MM-DD] query | <Question slug>`
+
+---
+
+## Lint Workflow
+
+When I ask for a wiki health check:
+
+1. Read all pages or use search to scan for issues.
+2. Report:
+   - **Contradictions**: Conflicting claims across pages
+   - **Stale content**: Claims superseded by newer ingested material
+   - **Orphan pages**: Pages with no inbound links
+   - **Missing pages**: Concepts mentioned multiple times but lacking their own page
+   - **Broken links**: `[[Page Name]]` links pointing to non-existent pages
+   - **Data gaps**: Areas where a targeted source or web search could fill in missing knowledge
+3. Suggest new questions to investigate and new sources to look for.
+4. Ask before making any fixes — report first, then fix with permission.
+5. Append to `wiki/log.md`: `## [YYYY-MM-DD] lint | health check`
+
+---
+
+## Style Preferences
+
+<!-- Customize to your preferences -->
+
+- **Voice**: Neutral, informative, encyclopedic — like Wikipedia
+- **Page length**: Aim for focused pages (300–800 words). Split if a page grows too large.
+- **Images**: Reference images from `raw/assets/` using relative paths: `![description](../raw/assets/image.png)`
+- **Tables**: Use markdown tables for comparisons; Dataview for dynamic lists
+- **Citations**: Always cite which source supports a claim, linking to `wiki/sources/<slug>`

--- a/skills/qmd-knowledge/SKILL.md
+++ b/skills/qmd-knowledge/SKILL.md
@@ -10,6 +10,8 @@ metadata:
   workflow: knowledge-management
 ---
 
+# QMD Knowledge
+
 ## What I do
 
 - Record and retrieve project learnings and insights

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd
-description: Guides through the complete TDD workflow with Red-Green-Refactor cycle
+description: Guide through the complete TDD workflow with Red-Green-Refactor cycle. Use when writing tests first, running Red-Green-Refactor cycles, or doing test-driven development.
 license: MIT
 compatibility: cline, claude, opencode, amp, codex, gemini, cursor, pi
 hint: Use when doing test-driven development with Red-Green-Refactor cycle
@@ -27,7 +27,6 @@ Guides you through the complete TDD workflow with Red-Green-Refactor cycle.
 - **cycle <FEATURE>** - Run complete Red-Green-Refactor cycle
 - **watch** - Start test watcher for continuous feedback
 - **status** - Show current test status and next steps
-- **help** - Show this help
 
 ## TDD Principles
 

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd
-description: Guide through the complete TDD workflow with Red-Green-Refactor cycle. Use when writing tests first, running Red-Green-Refactor cycles, or doing test-driven development.
+description: Guides through the complete TDD workflow with Red-Green-Refactor cycle. Use when writing tests first, running Red-Green-Refactor cycles, or doing test-driven development.
 license: MIT
 compatibility: cline, claude, opencode, amp, codex, gemini, cursor, pi
 hint: Use when doing test-driven development with Red-Green-Refactor cycle

--- a/skills/thermo-nuclear-code-quality-review/SKILL.md
+++ b/skills/thermo-nuclear-code-quality-review/SKILL.md
@@ -1,6 +1,13 @@
 ---
 name: thermo-nuclear-code-quality-review
 description: Run an extremely strict maintainability review for abstraction quality, giant files, and spaghetti-condition growth. Use for a thermo-nuclear code quality review, thermonuclear review, deep code quality audit, or especially harsh maintainability review.
+license: MIT
+compatibility: cline, claude, opencode, amp, codex, gemini, cursor, pi
+hint: Use when performing a deep, unusually strict code quality review focused on maintainability, abstraction quality, and eliminating complexity
+user-invocable: true
+metadata:
+  audience: all
+  workflow: code-quality
 disable-model-invocation: true
 ---
 


### PR DESCRIPTION
- **Initial plan**
- **feat: add LLM Wiki skill based on Karpathy's pattern**
- **refactor(llm-wiki): apply writing-great-skills principles**
- **refactor(skills): apply writing-great-skills principles to all skills**
- **fix(skills): use consistent verb tense in adr and tdd descriptions**
- **docs: add llm-wiki and missing skills to README listings**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new **llm-wiki** skill with workflows for init, ingest, query, lint, and status.
  * Added **llm-wiki** templates (index, log, and schema).
  * Updated the plugin marketplace to include new plugins and adjust ordering.

* **Documentation**
  * Expanded and refreshed multiple skill guides (available skills list, action/step updates, and improved wording/sections).
  * Updated skill metadata/details such as license and usage guidance.

* **Configuration**
  * Updated settings and model/MCP configurations (including a new disabled-by-default MCP fetch server), with JSON formatting cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->