### PR TITLE
docs: add Cursor Cloud dev environment instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,3 +126,19 @@ Read `@~/.ai-tools/agent-memory.md` and `@~/.ai-tools/MEMORY.md` for the full de
 - Prefer `git add <specific-files>` over `git add -A`
 - Never force push, rewrite history, or run destructive resets without explicit approval
 - See `configs/git-guidelines.md` for full rules
+
+## Cursor Cloud specific instructions
+
+This is a Bash CLI tool, not a long-running server — there is nothing to keep running. You verify it by invoking commands and checking exit codes / file output. The Linux VM already has `bash`, `git`, `jq`, `node`, `bun`, and `bats` provisioned (bun is on PATH via `~/.bashrc`; the update script refreshes `configs/claude/hooks` deps).
+
+- **Ignore the microsandbox (`msb`) guidance above** on the cloud VM — it only exists to dodge macOS `getcwd`/directory issues. Run `bats tests/` directly.
+- **Tests / lint / typecheck** — see the `## Testing` section above for the canonical commands (`bash -n cli.sh generate.sh`, `bats tests/`, `biome check .` via `npx @biomejs/biome`, and `bun run typecheck` in `configs/claude/hooks`).
+  - `biome check .` and the hooks `typecheck` report pre-existing formatting/`tsconfig` deviations (the tsconfig omits node/dom lib types); these are repo-state issues, not environment failures. The toolchains themselves run fine.
+- **Running the app safely** — `./cli.sh` / `./generate.sh` mutate `$HOME`. In a non-TTY/CI shell `cli.sh` auto-enables `--yes`, which tries to network-install ~20 external CLIs (many will fail/hang without network) *before* the core config copy at the very end. To exercise the core config-sync deterministically without that noise, source the script and call its copy functions against a throwaway `HOME`, exactly like the bats tests do:
+  ```bash
+  H=$(mktemp -d); mkdir -p "$H/.cursor" "$H/.config/opencode" "$H/.codex"
+  ( export HOME="$H" DRY_RUN=false YES_TO_ALL=false; source ./cli.sh; copy_configurations )
+  find "$H" -type f   # verify configs landed in the sandbox home
+  ```
+  `copy_claude_configs` always runs; other tools only copy when detected (their CLI is on PATH or their config dir exists — hence pre-creating dirs above). Do NOT run the copy functions with `set -u`; `lib/common.sh` references optional vars like `MSYSTEM`.
+- Use `./cli.sh --dry-run` for a full, side-effect-free preview of the install plan.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up and verifies the Cloud Agent development environment for `my-ai-tools`, and documents non-obvious startup/run caveats for future agents under a new `## Cursor Cloud specific instructions` section in `AGENTS.md`.

This is a Bash CLI tool (not a server). Core deps (`bash`, `git`, `jq`, `node`) were already present; I provisioned the missing pieces (`bats` for the test suite, `bun` for the TS hooks) into the VM. The only repo change is `AGENTS.md`.

## Environment verification

- ✅ `bash -n cli.sh generate.sh lib/*.sh` — no syntax errors (CI gate)
- ✅ `bats tests/` — **378 passed, 0 failed**
- ✅ `./cli.sh --dry-run` — full install plan previews correctly
- ✅ Hello-world: ran the real core `copy_configurations` against a sandbox `HOME` — 56 config files synced for detected tools (Claude/Cursor/Codex/OpenCode/Pi/Copilot/Codiff) and verified byte-identical to source

Verification logs:
[env_verification.log](https://cursor.com/agents/bc-adea1224-21c5-4531-a4dc-283ea860f1b0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenv_verification.log)

## Update script

Refreshes the optional TS hooks deps only (core CLI needs no installable deps):
```
if [ -f configs/claude/hooks/package.json ]; then
  BUN_BIN="$(command -v bun || echo "$HOME/.bun/bin/bun")"
  if [ -x "$BUN_BIN" ]; then (cd configs/claude/hooks && "$BUN_BIN" install); fi
fi
```

## Notes

- `biome check .` and the hooks `typecheck` report pre-existing formatting/`tsconfig` deviations (repo state, not env failures); the toolchains run fine. No code was modified.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adea1224-21c5-4531-a4dc-283ea860f1b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adea1224-21c5-4531-a4dc-283ea860f1b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for using Cursor Cloud environments.
  * Clarified the preferred test, lint, and typecheck commands.
  * Documented a safe preview workflow for running setup scripts without side effects.
  * Noted which configuration copies always run and which depend on available tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->