### PR TITLE
docs: add Devin CLI to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub license](https://img.shields.io/github/license/jellydn/my-ai-tools)](https://github.com/jellydn/my-ai-tools/blob/main/LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/jellydn/my-ai-tools/pulls)
 
-> **Comprehensive configuration management for AI coding tools** - Replicate my complete setup for Claude Code, OpenCode, Amp, Kilo CLI, Codex, Kimi Code, Gemini CLI, Antigravity CLI, Pi, GitHub Copilot CLI, Cursor Agent CLI, Factory Droid, Cline, Grok CLI, MiMo-Code, Qoder CLI, Kiro CLI, Codiff, ctx, Open Code Review, and CCS with custom configurations, MCP servers, skills, plugins, and commands.
+> **Comprehensive configuration management for AI coding tools** - Replicate my complete setup for Claude Code, OpenCode, Amp, Kilo CLI, Codex, Devin CLI, Kimi Code, Gemini CLI, Antigravity CLI, Pi, GitHub Copilot CLI, Cursor Agent CLI, Factory Droid, Cline, Grok CLI, MiMo-Code, Qoder CLI, Kiro CLI, Codiff, ctx, Open Code Review, and CCS with custom configurations, MCP servers, skills, plugins, and commands.
 
 📖 **[View Documentation Website](https://ai-tools.itman.fyi)** - Interactive landing page with full documentation and search.
 
@@ -12,12 +12,19 @@
 
 - 🚀 **One-line installer** - Get started in seconds
 - 🔄 **Bidirectional sync** - Install configs or export your current setup
-- 🤖 **Multiple AI tools** - Claude Code, OpenCode, Amp, CCS, Kimi Code, Gemini, Antigravity, Grok, MiMo-Code, Qoder CLI, Kiro CLI, Codiff, ctx, Open Code Review, and more
+- 🤖 **Multiple AI tools** - Claude Code, OpenCode, Amp, CCS, Devin, Kimi Code, Gemini, Antigravity, Grok, MiMo-Code, Qoder CLI, Kiro CLI, Codiff, ctx, Open Code Review, and more
 - 🔌 **MCP Server integration** - Context7, Sequential-thinking, qmd, codebase-memory-mcp, agentmemory, sem, ctx
 - 🎯 **Custom agents & skills** - Pre-configured for maximum productivity
 - 🤝 **Agent Teams** - Coordinate specialized agents for complex workflows (code review, testing, docs)
 - 📦 **Plugin support** - Official and community plugins
 - 🛡️ **Git Guard Hook** - Prevents dangerous git commands (force push, hard reset, etc.)
+
+## Devin CLI
+
+Devin CLI is a local command-line coding agent with deep Devin Cloud integration.
+
+- Install: `curl -fsSL https://cli.devin.ai/install.sh | bash`
+- Run: `devin -- "check out this code and suggest a feasible, helpful feature"`
 
 ## ⭐ Top 5 Skills
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,102 @@
 - 📦 **Plugin support** - Official and community plugins
 - 🛡️ **Git Guard Hook** - Prevents dangerous git commands (force push, hard reset, etc.)
 
-## Devin CLI
+## 🖥️ Devin CLI (Optional)
 
-Devin CLI is a local command-line coding agent with deep Devin Cloud integration.
+Cognition AI's autonomous coding agent with deep cloud integration. [Homepage](https://devin.ai) | [Docs](https://docs.devin.ai)
 
-- Install: `curl -fsSL https://cli.devin.ai/install.sh | bash`
-- Run: `devin -- "check out this code and suggest a feasible, helpful feature"`
+<details>
+<summary><strong>Installation & Configuration</strong></summary>
+
+### Installation
+
+```bash
+curl -fsSL https://cli.devin.ai/install.sh | bash
+```
+
+### Configuration
+
+Run the setup script to install configurations to `~/.config/devin/`:
+
+```bash
+./cli.sh
+```
+
+The setup script automatically deploys MCP servers and agent guidelines.
+
+### MCP Servers
+
+Configuration in [`configs/devin/config.json`](configs/devin/config.json):
+
+```json
+{
+	"mcpServers": {
+		"context7": {
+			"command": "npx",
+			"args": ["-y", "@upstash/context7-mcp@latest"]
+		},
+		"sequential-thinking": {
+			"command": "npx",
+			"args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+		},
+		"qmd": {
+			"command": "qmd",
+			"args": ["mcp"]
+		},
+		"fff": {
+			"type": "stdio",
+			"command": "fff-mcp",
+			"args": []
+		},
+		"react-grab-mcp": {
+			"command": "npx",
+			"args": ["-y", "@react-grab/mcp", "--stdio"]
+		},
+		"logpilot": {
+			"command": "logpilot",
+			"args": ["mcp-server"]
+		},
+		"agentmemory": {
+			"command": "npx",
+			"args": ["-y", "@agentmemory/mcp"]
+		},
+		"sem": {
+			"command": "sem-mcp",
+			"args": []
+		},
+		"ctx": {
+			"command": "ctx",
+			"args": ["mcp", "serve"]
+		},
+		"codebase-memory-mcp": {
+			"command": "codebase-memory-mcp",
+			"args": []
+		}
+	}
+}
+```
+
+### Agent Guidelines
+
+Installed to `~/.config/devin/AGENTS.md` with instructions for:
+
+- Session management with tmux
+- Using fff MCP for file search
+- Following best practices from `~/.ai-tools/best-practices.md`
+- qmd knowledge management integration
+- Git safety guidelines
+
+### Usage
+
+```bash
+# Start Devin CLI
+devin
+
+# Run with a specific task
+devin -- "check out this code and suggest a feasible, helpful feature"
+```
+
+</details>
 
 ## ⭐ Top 5 Skills
 

--- a/cli.sh
+++ b/cli.sh
@@ -2536,6 +2536,13 @@ main() {
 	fi
 	echo
 
+	if tool_allowed "devin"; then
+		install_devin
+	else
+		log_info "Skipping devin installer (not in -y allowlist)"
+	fi
+	echo
+
 	if tool_allowed "factory"; then
 		install_factory
 	else

--- a/cli.sh
+++ b/cli.sh
@@ -287,6 +287,7 @@ backup_configs() {
 		copy_config_dir "$HOME/.qoder" "$BACKUP_DIR" "qodercli"
 		copy_config_dir "$HOME/.kiro" "$BACKUP_DIR" "kiro"
 		copy_config_dir "$HOME/.codiff" "$BACKUP_DIR" "codiff"
+		copy_config_dir "$HOME/.config/devin" "$BACKUP_DIR" "devin"
 		copy_config_dir "$HOME/.ctx" "$BACKUP_DIR" "ctx"
 		copy_config_file "$HOME/.config/ai-launcher/config.json" "$BACKUP_DIR/ai-launcher" || true
 
@@ -519,6 +520,11 @@ copy_configurations() {
 		copy_codiff_configs
 	else
 		log_info "Skipping codiff config install (not in -y allowlist)"
+	fi
+	if tool_allowed "devin"; then
+		copy_devin_configs
+	else
+		log_info "Skipping devin config install (not in -y allowlist)"
 	fi
 	if tool_allowed "factory"; then
 		copy_factory_configs
@@ -1619,6 +1625,23 @@ copy_codiff_configs() {
 	log_success "Codiff configs copied"
 }
 
+copy_devin_configs() {
+	local devin_status
+	devin_status=$(detect_tool --detailed "devin" "$HOME/.config/devin") || devin_status="missing"
+	if [ "$devin_status" = "missing" ]; then
+		log_info "Devin CLI not detected - skipping Devin config installation"
+		return 0
+	fi
+
+	log_info "Detected Devin CLI (via $devin_status)"
+	execute_quoted mkdir -p "$HOME/.config/devin"
+
+	copy_config_file "$SCRIPT_DIR/configs/devin/AGENTS.md" "$HOME/.config/devin/" || true
+	copy_config_file "$SCRIPT_DIR/configs/devin/config.json" "$HOME/.config/devin/" || true
+
+	log_success "Devin CLI configs copied"
+}
+
 copy_factory_configs() {
 	local factory_status
 	factory_status=$(detect_tool --detailed "droid" "$HOME/.factory") || factory_status="missing"
@@ -2351,7 +2374,7 @@ main() {
 	echo "║  Claude • OpenCode • Amp • CCS • Codex • Kimi Code • Gemini          ║"
 	echo "║  Antigravity • Pi • Kilo • Copilot • Cursor • Command Code           ║"
 	echo "║  Factory Droid • Cline • Grok • MiMo-Code • herdr                    ║"
-	echo "║  Qoder CLI • Kiro • Codiff                                           ║"
+	echo "║  Qoder CLI • Kiro • Codiff • Devin                                   ║"
 	echo "║  ctx                                                                 ║"
 	echo "╚══════════════════════════════════════════════════════════════════════╝"
 	echo

--- a/configs/devin/AGENTS.md
+++ b/configs/devin/AGENTS.md
@@ -1,0 +1,43 @@
+# 🤖 Devin CLI Agent Guidelines
+
+## Session Management with tmux
+
+Run dev servers, tests, and interactive CLIs inside tmux with the **current directory name as the session name** for easy debugging:
+
+```bash
+SESSION=$(basename "$PWD")
+tmux new -d -s "$SESSION" 2>/dev/null || true
+
+# Run dev server with portless if available, otherwise fallback to npm
+if command -v portless &>/dev/null; then
+    tmux send-keys -t "$SESSION" 'portless run npm run dev' Enter
+else
+    tmux send-keys -t "$SESSION" 'npm run dev' Enter
+fi
+
+tmux capture-pane -p -t "$SESSION" -S -20  # check output
+```
+
+See @~/.ai-tools/best-practices.md for full details.
+
+## 🔧 AI Tool Guidelines
+
+- Use the fff MCP tools for all file search operations instead of default tools.
+- Use the sem MCP tools for semantic version control and git operations.
+- When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
+
+## 📋 General Practices
+
+- Follow my software development practice @~/.ai-tools/best-practices.md
+- Read @~/.ai-tools/MEMORY.md first — qmd (durable) vs agentmemory (session); follow the decision rule there
+- Read @~/.ai-tools/agent-memory.md — auto-capture learnings, persist bug fixes, keep memories concise. After fixing a bug (confirmed by human), introducing a new tech choice, or encountering something important, ask: "Would you like me to record this as a learning?"
+- Follow git safety guidelines @~/.ai-tools/git-guidelines.md
+- Keep responses concise and actionable.
+- Always propose a plan before edits. Use phases to break down tasks into manageable steps.
+- Run typecheck, lint and biome on js/ts file changes after finish
+- Prefer to use Bun to run scripts if possible, otherwise use tsx to run ts files.
+- Ask before destructive operations — don't guess safety
+- Code is communication — prefer clarity and simplicity
+- Self-documenting code through meaningful names and structure
+- Modular design that can evolve
+- Comments explain why, not what

--- a/configs/devin/config.json
+++ b/configs/devin/config.json
@@ -1,0 +1,45 @@
+{
+	"mcpServers": {
+		"context7": {
+			"command": "npx",
+			"args": ["-y", "@upstash/context7-mcp@latest"]
+		},
+		"sequential-thinking": {
+			"command": "npx",
+			"args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+		},
+		"qmd": {
+			"command": "qmd",
+			"args": ["mcp"]
+		},
+		"fff": {
+			"type": "stdio",
+			"command": "fff-mcp",
+			"args": []
+		},
+		"react-grab-mcp": {
+			"command": "npx",
+			"args": ["-y", "@react-grab/mcp", "--stdio"]
+		},
+		"logpilot": {
+			"command": "logpilot",
+			"args": ["mcp-server"]
+		},
+		"agentmemory": {
+			"command": "npx",
+			"args": ["-y", "@agentmemory/mcp"]
+		},
+		"sem": {
+			"command": "sem-mcp",
+			"args": []
+		},
+		"ctx": {
+			"command": "ctx",
+			"args": ["mcp", "serve"]
+		},
+		"codebase-memory-mcp": {
+			"command": "codebase-memory-mcp",
+			"args": []
+		}
+	}
+}

--- a/generate.sh
+++ b/generate.sh
@@ -786,6 +786,22 @@ generate_codiff_configs() {
 	log_success "Codiff configs generated"
 }
 
+generate_devin_configs() {
+	log_info "Generating Devin CLI configs..."
+
+	if [ ! -d "$HOME/.config/devin" ]; then
+		log_warning "Devin CLI config directory not found: $HOME/.config/devin"
+		return 0
+	fi
+
+	execute "mkdir -p \"$SCRIPT_DIR/configs/devin\""
+
+	copy_single "$HOME/.config/devin/AGENTS.md" "$SCRIPT_DIR/configs/devin/AGENTS.md"
+	copy_single "$HOME/.config/devin/config.json" "$SCRIPT_DIR/configs/devin/config.json"
+
+	log_success "Devin CLI configs generated"
+}
+
 generate_cline_configs() {
 	log_info "Generating Cline configs..."
 
@@ -949,6 +965,9 @@ main() {
 	echo
 
 	generate_codiff_configs
+	echo
+
+	generate_devin_configs
 	echo
 
 	generate_best_practices

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -1100,3 +1100,29 @@ install_codiff() {
 	}
 	run_installer "Codiff" "_run_codiff_install" "command -v codiff" "codiff --version 2>/dev/null || true"
 }
+
+# ─── devin installation ───────────────────────────────────────────
+
+install_devin() {
+	_run_devin_install() {
+		if command -v devin &>/dev/null; then
+			log_warning "Devin CLI is already installed"
+			return 0
+		fi
+
+		if [ "$IS_WINDOWS" = true ]; then
+			if command -v powershell.exe &>/dev/null; then
+				execute "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"irm https://static.devin.ai/cli/setup.ps1 | iex\""
+			else
+				log_error "PowerShell is required to install Devin CLI on Windows."
+				log_info "Install manually: https://docs.devin.ai"
+				return 1
+			fi
+		else
+			execute_installer "https://cli.devin.ai/install.sh" "" "Devin CLI"
+		fi
+
+		log_success "Devin CLI installed"
+	}
+	run_installer "Devin CLI" "_run_devin_install" "command -v devin" "devin --version 2>/dev/null || true"
+}

--- a/tests/pr_devin.bats
+++ b/tests/pr_devin.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/env bats
+# Tests for Devin CLI support
+
+load helpers
+
+REPO_ROOT="$BATS_TEST_DIRNAME/.."
+README="$REPO_ROOT/README.md"
+
+@test "README.md mentions Devin CLI in the supported-tools list" {
+    run grep -F "Devin CLI" "$README"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "README.md has a Devin CLI section with the official installer" {
+    run grep -F "https://cli.devin.ai/install.sh" "$README"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "README.md shows the devin command example" {
+    run grep -F 'devin -- "check out this code and suggest a feasible, helpful feature"' "$README"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}

--- a/tests/pr_devin.bats
+++ b/tests/pr_devin.bats
@@ -5,6 +5,7 @@ load helpers
 
 REPO_ROOT="$BATS_TEST_DIRNAME/.."
 README="$REPO_ROOT/README.md"
+CONFIG_DIR="$REPO_ROOT/configs/devin"
 
 @test "README.md mentions Devin CLI in the supported-tools list" {
     run grep -F "Devin CLI" "$README"
@@ -22,4 +23,29 @@ README="$REPO_ROOT/README.md"
     run grep -F 'devin -- "check out this code and suggest a feasible, helpful feature"' "$README"
     [ "$status" -eq 0 ]
     [ -n "$output" ]
+}
+
+@test "README.md has Devin MCP servers section" {
+    run grep -F "configs/devin/config.json" "$README"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "configs/devin/config.json exists and is valid JSON" {
+    run jq empty "$CONFIG_DIR/config.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "configs/devin/config.json has mcpServers" {
+    run jq -e '.mcpServers' "$CONFIG_DIR/config.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "configs/devin/AGENTS.md exists" {
+    [ -f "$CONFIG_DIR/AGENTS.md" ]
+}
+
+@test "configs/devin/AGENTS.md references best-practices" {
+    run grep -F "best-practices.md" "$CONFIG_DIR/AGENTS.md"
+    [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## What
- Add Devin CLI to the supported tools list in the README.
- Add a short Devin CLI section with install and run examples.
- Add a focused Bats test for the new documentation.

## Why
- Devin is part of the AI toolset list and should be documented alongside the other supported CLIs.

## How
- Update the top-level description and feature list in `README.md`.
- Add a Devin CLI section with the official installer command and example invocation.
- Add `tests/pr_devin.bats` to keep the documentation coverage in place.

## Verification
- `bats tests/pr_devin.bats tests/pr_readme.bats`