### PR TITLE
fix(deploy): OpenRouter base URL and Fly CI secret validation

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -46,8 +46,7 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-        run: |
-          printf "OPENAI_API_KEY=%s\n" "$OPENAI_API_KEY" | flyctl secrets import
+        run: flyctl secrets set OPENAI_API_KEY="$OPENAI_API_KEY"
 
       - name: Deploy to Fly.io
         env:

--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -23,7 +23,26 @@ jobs:
       - name: Setup flyctl
         uses: superfly/flyctl-actions/setup-flyctl@master
 
-      - name: Import runtime secrets
+      - name: Validate required secrets
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          missing=0
+
+          if [ -z "$FLY_API_TOKEN" ]; then
+            echo "::error::GitHub secret FLY_API_TOKEN is not set. Add a Fly deploy token in Settings → Secrets and variables → Actions."
+            missing=1
+          fi
+
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "::error::GitHub secret OPENAI_API_KEY is not set. Add your OpenRouter key (sk-or-v1-...) as OPENAI_API_KEY."
+            missing=1
+          fi
+
+          exit "$missing"
+
+      - name: Import OpenRouter API key to Fly
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/docs/fly-deploy.md
+++ b/docs/fly-deploy.md
@@ -1,0 +1,33 @@
+# Fly.io deploy (GitHub Actions)
+
+The workflow [`.github/workflows/fly.yml`](../.github/workflows/fly.yml) deploys app `ai-tools-itman-fyi` on push to `main` or via **workflow_dispatch**.
+
+## Required GitHub Actions secrets
+
+Configure these under **Settings → Secrets and variables → Actions** for the repository:
+
+| Secret | Value |
+|--------|--------|
+| `FLY_API_TOKEN` | Fly **deploy** token (not your personal login). Create with: `fly tokens create deploy` (while logged in with `flyctl auth login` locally). |
+| `OPENAI_API_KEY` | Your [OpenRouter](https://openrouter.ai/) API key (`sk-or-v1-...`). **Not** an OpenAI `sk-proj-...` key — the app talks to `https://openrouter.ai/api/v1` (see `fly.toml`). |
+
+If either secret is missing, the workflow fails at **Validate required secrets** with an explicit error. The message `no access token available. Please login with 'flyctl auth login'` means **`FLY_API_TOKEN` was empty** in CI — do not add an interactive `flyctl auth login` step; use the deploy token secret instead.
+
+## Runtime model configuration (already in repo)
+
+Non-secret OpenAI-compatible settings are in [`fly.toml`](../fly.toml) and match [`.env.example`](../.env.example):
+
+- `OPENAI_BASE_URL` = `https://openrouter.ai/api/v1`
+- `OPENAI_MODEL` = `openrouter/free` ([free models collection](https://openrouter.ai/collections/free-models))
+- `OPENAI_EMBEDDING_MODEL` = `nvidia/llama-nemotron-embed-vl-1b-v2:free`
+
+No workflow change is required for OpenRouter free models once `OPENAI_API_KEY` is set.
+
+## Local deploy (optional)
+
+```bash
+flyctl auth login
+export OPENAI_API_KEY="sk-or-v1-..."
+flyctl secrets import < <(printf 'OPENAI_API_KEY=%s\n' "$OPENAI_API_KEY")
+flyctl deploy --remote-only --build-secret "OPENAI_API_KEY=$OPENAI_API_KEY"
+```

--- a/docs/fly-deploy.md
+++ b/docs/fly-deploy.md
@@ -28,6 +28,6 @@ No workflow change is required for OpenRouter free models once `OPENAI_API_KEY` 
 ```bash
 flyctl auth login
 export OPENAI_API_KEY="sk-or-v1-..."
-flyctl secrets import < <(printf 'OPENAI_API_KEY=%s\n' "$OPENAI_API_KEY")
+flyctl secrets set OPENAI_API_KEY="$OPENAI_API_KEY"
 flyctl deploy --remote-only --build-secret "OPENAI_API_KEY=$OPENAI_API_KEY"
 ```

--- a/lib/openai-client.ts
+++ b/lib/openai-client.ts
@@ -1,0 +1,11 @@
+import OpenAI from "openai";
+
+/** OpenAI-compatible client (OpenAI, OpenRouter, etc.) from env. */
+export function createOpenAIClient(): OpenAI {
+	const apiKey = process.env.OPENAI_API_KEY;
+	if (!apiKey) {
+		throw new Error("OPENAI_API_KEY is not set");
+	}
+	const baseURL = process.env.OPENAI_BASE_URL;
+	return baseURL ? new OpenAI({ apiKey, baseURL }) : new OpenAI({ apiKey });
+}

--- a/lib/openai-client.ts
+++ b/lib/openai-client.ts
@@ -2,10 +2,10 @@ import OpenAI from "openai";
 
 /** OpenAI-compatible client (OpenAI, OpenRouter, etc.) from env. */
 export function createOpenAIClient(): OpenAI {
-	const apiKey = process.env.OPENAI_API_KEY;
+	const apiKey = process.env.OPENAI_API_KEY?.trim();
 	if (!apiKey) {
 		throw new Error("OPENAI_API_KEY is not set");
 	}
-	const baseURL = process.env.OPENAI_BASE_URL;
+	const baseURL = process.env.OPENAI_BASE_URL?.trim();
 	return baseURL ? new OpenAI({ apiKey, baseURL }) : new OpenAI({ apiKey });
 }

--- a/lib/retriever.ts
+++ b/lib/retriever.ts
@@ -1,7 +1,8 @@
 import { readFile, stat } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import OpenAI from "openai";
+import type OpenAI from "openai";
+import { createOpenAIClient } from "./openai-client.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -34,11 +35,7 @@ let indexCacheSize = 0;
 
 function getClient(): OpenAI {
 	if (!openai) {
-		const apiKey = process.env.OPENAI_API_KEY;
-		if (!apiKey) {
-			throw new Error("OPENAI_API_KEY is not set");
-		}
-		openai = new OpenAI({ apiKey });
+		openai = createOpenAIClient();
 	}
 	return openai;
 }

--- a/scripts/index-repo.ts
+++ b/scripts/index-repo.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import OpenAI from "openai";
+import { createOpenAIClient } from "../lib/openai-client.ts";
 import { indexRepository } from "../lib/indexer.ts";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -14,12 +14,7 @@ const EMBEDDING_BATCH_SIZE = 100;
 const EMBEDDING_MODEL = process.env.OPENAI_EMBEDDING_MODEL ?? "text-embedding-3-small";
 
 async function createEmbeddings(chunks: string[]): Promise<number[][]> {
-	const apiKey = process.env.OPENAI_API_KEY;
-	if (!apiKey) {
-		throw new Error("OPENAI_API_KEY is not set");
-	}
-
-	const openai = new OpenAI({ apiKey });
+	const openai = createOpenAIClient();
 	const embeddings: number[][] = [];
 
 	for (let i = 0; i < chunks.length; i += EMBEDDING_BATCH_SIZE) {

--- a/server.ts
+++ b/server.ts
@@ -4,8 +4,8 @@ import { serveStatic } from "@hono/node-server/serve-static";
 import type { Context, Next } from "hono";
 import { Hono } from "hono";
 import { stream } from "hono/streaming";
-import OpenAI from "openai";
 import { z } from "zod";
+import { createOpenAIClient } from "./lib/openai-client.ts";
 import { type RetrievedChunk, retrieve } from "./lib/retriever.ts";
 
 const [indexHtml, installSh, installPs1] = await Promise.all([
@@ -20,7 +20,8 @@ const requestTimestamps = new Map<string, number[]>();
 
 function rateLimitMiddleware(c: Context, next: Next) {
 	const forwarded = c.req.header("x-forwarded-for");
-	const clientIp = c.req.header("fly-client-ip") || (forwarded ? forwarded.split(",")[0]?.trim() : undefined);
+	const clientIp =
+		c.req.header("fly-client-ip") || (forwarded ? forwarded.split(",")[0]?.trim() : undefined);
 	const key = clientIp ?? "unknown";
 	const now = Date.now();
 	const timestamps = requestTimestamps.get(key) ?? [];
@@ -56,9 +57,7 @@ if (!process.env.OPENAI_API_KEY) {
 	process.exit(1);
 }
 
-const openai = new OpenAI({
-	apiKey: process.env.OPENAI_API_KEY,
-});
+const openai = createOpenAIClient();
 
 const chatRequestSchema = z.object({
 	message: z.string().min(1).max(4000),
@@ -98,8 +97,16 @@ app.post("/api/chat", rateLimitMiddleware, async (c) => {
 	try {
 		chunks = await retrieve(message, 5);
 	} catch (error) {
-		if (error && typeof error === "object" && "code" in error && (error as { code: unknown }).code === "ENOENT") {
-			return c.json({ error: "Index not found. Run `bun run index` to build data/index.json." }, 503);
+		if (
+			error &&
+			typeof error === "object" &&
+			"code" in error &&
+			(error as { code: unknown }).code === "ENOENT"
+		) {
+			return c.json(
+				{ error: "Index not found. Run `bun run index` to build data/index.json." },
+				503,
+			);
 		}
 		return c.json({ error: "Failed to retrieve context from the index." }, 500);
 	}
@@ -107,7 +114,9 @@ app.post("/api/chat", rateLimitMiddleware, async (c) => {
 	if (chunks.length === 0) {
 		c.header("Content-Type", "text/plain; charset=utf-8");
 		return stream(c, async (stream) => {
-			await stream.write(`${JSON.stringify({ type: "text", content: "This is not documented in the repository." })}\n`);
+			await stream.write(
+				`${JSON.stringify({ type: "text", content: "This is not documented in the repository." })}\n`,
+			);
 			await stream.write(`${JSON.stringify({ type: "sources", paths: [] })}\n`);
 		});
 	}


### PR DESCRIPTION
## What

- Add **Validate required secrets** to `.github/workflows/fly.yml` so missing `FLY_API_TOKEN` or `OPENAI_API_KEY` fails with clear `::error::` messages before `flyctl` runs.
- Introduce `lib/openai-client.ts` and use it from `server.ts`, `scripts/index-repo.ts`, and `lib/retriever.ts` so `OPENAI_BASE_URL` (OpenRouter in `fly.toml`) is honored during Docker index build and at runtime.
- Add `docs/fly-deploy.md` documenting GitHub secrets, deploy tokens vs `flyctl auth login`, and OpenRouter free model env vars.

## Why

Fly Deploy in CI failed with `no access token available` when GitHub secrets were empty, and with OpenRouter `401 Missing Authentication header` during image build because embedding calls used the default OpenAI API host instead of `https://openrouter.ai/api/v1`.

## How

- Centralize OpenAI SDK construction: pass `baseURL` when `OPENAI_BASE_URL` is set (matches `.env.example` / `fly.toml`).
- Fail fast in the workflow on unset secrets; rename import step for clarity.
- Document that `OPENAI_API_KEY` must be an OpenRouter `sk-or-v1-...` key for this deployment, not an OpenAI `sk-proj-...` key.

## Checklist

- [ ] Tests added or updated
- [x] Documentation updated
- [x] No breaking changes (or breaking changes documented above)