### PR TITLE
feat: evaluate and improve RAG retrieval quality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ OPENAI_MODEL=openrouter/free
 OPENAI_EMBEDDING_MODEL=nvidia/llama-nemotron-embed-vl-1b-v2:free
 GITHUB_REPOSITORY=jellydn/my-ai-tools
 GITHUB_TOKEN=
+GITHUB_SOURCE_REF=main

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,11 @@ COPY . .
 ARG OPENAI_BASE_URL=https://openrouter.ai/api/v1
 ARG OPENAI_MODEL=openrouter/free
 ARG OPENAI_EMBEDDING_MODEL=nvidia/llama-nemotron-embed-vl-1b-v2:free
+ARG GITHUB_SOURCE_REF=main
 ENV OPENAI_BASE_URL=${OPENAI_BASE_URL}
 ENV OPENAI_MODEL=${OPENAI_MODEL}
 ENV OPENAI_EMBEDDING_MODEL=${OPENAI_EMBEDDING_MODEL}
+ENV GITHUB_SOURCE_REF=${GITHUB_SOURCE_REF}
 
 # Secret is only visible in this RUN; export so npm run index inherits a trimmed key.
 RUN --mount=type=secret,id=OPENAI_API_KEY,required=true \

--- a/README.md
+++ b/README.md
@@ -284,13 +284,13 @@ source .env            # load OPENAI_BASE_URL for server mode
 npm run dev            # serve http://localhost:3000
 ```
 
-The grounding prompt directs the assistant to answer only from retrieved repository excerpts and to say "This is not documented in the repository." when the context is insufficient. The UI separately displays the five retrieved sources as a verifiable retrieval trace; it does not claim to validate every generated statement against a citation.
+The grounding prompt directs the assistant to answer only from retrieved repository excerpts and to say "This is not documented in the repository." when the context is insufficient. The UI separately displays the retrieved sources as a verifiable retrieval trace; it does not claim to validate every generated statement against a citation.
 
-The implementation intentionally avoids LangChain: the document loader, 1,000-character chunking with 150-character overlap, embedding calls, cosine retrieval (top 5), prompt assembly, and source-link handling are explicit TypeScript modules. GitHub documents carry `type`, `author`, and canonical URL metadata so metadata filtering can be added without rebuilding the index format. Set `GITHUB_TOKEN` while indexing to avoid anonymous GitHub API limits; `GITHUB_REPOSITORY` defaults to `jellydn/my-ai-tools`.
+The implementation intentionally avoids LangChain: the document loader, 1,000-character chunking with 150-character overlap, embedding calls, cosine retrieval, prompt assembly, and source-link handling are explicit TypeScript modules. `POST /api/chat` accepts `topK` (`3`, `5`, `10`, or `20`, default `5`) and an optional `types` array containing `documentation`, `source`, `issue`, `pull_request`, `cli_help`, or `example_config`. Metadata is filtered before vector scoring. Set `GITHUB_TOKEN` while indexing to avoid anonymous GitHub API limits; `GITHUB_REPOSITORY` defaults to `jellydn/my-ai-tools`.
 
-Each server request writes one structured `rag_request` JSON log containing the question, five retrieved chunks and similarity scores, prompt/response tokens reported by the model provider, total latency, and any failure stage. Browser mode records equivalent diagnostics in the browser console.
+Each server request writes one structured `rag_request` JSON log containing question length, retrieval settings, retrieved chunks and similarity scores, retrieval and total latency, prompt/response tokens reported by the model provider, and any failure stage. Raw questions, hashes, embeddings, and credentials are not logged. Browser mode records equivalent diagnostics in the browser console.
 
-See [`docs/rag-architecture.md`](docs/rag-architecture.md) for the architecture, indexing policy, observability fields, and planned production upgrades.
+Run `npm run eval:retrieval` after building the browser index to reproduce the top-k, filtering, and trace benchmark. See [`docs/rag-retrieval-quality.md`](docs/rag-retrieval-quality.md) for results and [`docs/rag-architecture.md`](docs/rag-architecture.md) for the architecture and indexing policy.
 
 The landing page also has a browser mode that runs the embedding and an instruction-tuned model (Qwen2.5-Coder-0.5B-Instruct) in the browser via WebGPU. Browser mode downloads the ~9 MB index and the ~300 MB model on the user's device.
 

--- a/docs/rag-architecture.md
+++ b/docs/rag-architecture.md
@@ -19,7 +19,7 @@ Repository + GitHub Issues/PRs
  In-image vector index (JSON)
             │
             ▼
- Cosine retriever (top 5)
+ Cosine retriever + metadata filter
             │
             ▼
  Grounding prompt policy
@@ -50,11 +50,11 @@ type ChunkMetadata = {
 };
 ```
 
-This supports future filters such as `type=issue`, `path=docs/`, or `author=jellydn` without changing the index schema.
+This supports pre-filtering by document type without changing the index schema. Path and author filters remain future extensions.
 
 ## Retrieval and grounding
 
-The server embeds the question with the same model used at index time, calculates cosine similarity against every chunk, and sends the five highest-scoring chunks to the answer model. The prompt treats excerpts as untrusted data, requires answers to use only those excerpts, cite relevant paths, and return `This is not documented in the repository.` when the evidence is insufficient. The UI appends deduplicated links for the retrieved sources, including direct links for Issues and Pull Requests. These links are a retrieval trace rather than a claim-level citation validator.
+The server embeds the question with the same model used at index time, optionally filters candidates by document type, calculates cosine similarity, and sends the requested top 3, 5, 10, or 20 chunks to the answer model. Top 5 remains the default. The prompt treats excerpts as untrusted data, requires answers to use only those excerpts, cite relevant paths, and return `This is not documented in the repository.` when the evidence is insufficient. The UI appends deduplicated links for the retrieved sources, including direct links for Issues and Pull Requests. Local-file links use `GITHUB_SOURCE_REF`; deployments should pass the indexed commit SHA as a Docker build argument so links do not silently drift with `main`. These links are a retrieval trace rather than a claim-level citation validator.
 
 The JSON vector index is an intentional first production step: the corpus fits in one Fly machine image, deployment is stateless, and there is no external database to operate. pgvector becomes appropriate when the corpus or update frequency makes rebuilding the image too slow, or when multiple application instances need incremental index updates.
 
@@ -65,8 +65,11 @@ Server mode emits one JSON log per accepted request:
 ```json
 {
   "event": "rag_request",
-  "question": "How do I add an MCP server?",
+  "questionLength": 27,
+  "topK": 5,
+  "filters": { "types": ["documentation", "example_config"] },
   "retrievedChunks": [{ "path": "README.md", "type": "documentation", "score": 0.8123 }],
+  "retrievalLatencyMs": 18,
   "promptTokens": 1420,
   "responseTokens": 186,
   "latencyMs": 934
@@ -75,11 +78,11 @@ Server mode emits one JSON log per accepted request:
 
 Failures include an `error` stage. Token counts are `null` if an OpenAI-compatible provider does not report streaming usage. Browser mode logs equivalent retrieval and timing details to the browser console.
 
-These logs make it possible to build an evaluation set, inspect poor retrieval, compare chunking strategies, and track latency/cost without logging embeddings or API credentials. Questions may contain sensitive text, so production log retention and access must be configured accordingly.
+These logs make it possible to inspect poor retrieval, compare settings, and track latency/cost without logging raw questions, prompt hashes, embeddings, or API credentials. Production log retention and access controls are still required.
 
 ## Production roadmap
 
-1. Add metadata filters to the API and chat UI.
+1. Add filter controls to the chat UI and extend filtering to path and author.
 2. Add BM25 retrieval, merge it with vector results, and retrieve an initial top 20.
 3. Rerank those 20 candidates down to the five chunks sent to the model.
 4. Move vectors to pgvector when incremental updates or horizontal scaling justify the operational cost.

--- a/docs/rag-retrieval-quality.md
+++ b/docs/rag-retrieval-quality.md
@@ -1,0 +1,99 @@
+# Day 11: retrieval quality
+
+This evaluation changes retrieval, not the answer model. The repeatable benchmark uses the browser index and the three questions in `scripts/evaluate-retrieval.ts`. Build with the exact source revision, then run:
+
+```bash
+GITHUB_SOURCE_REF="$(git rev-parse HEAD)" npm run index:browser
+npm run eval:retrieval
+npm run eval:retrieval -- --check-links
+```
+
+“Answer-support rate” is a retrieval-only proxy: at least one human-labeled supporting path was retrieved. It is not an LLM-as-judge score. Prompt tokens are estimated from context characters because the embedding-only benchmark deliberately does not invoke or change the LLM. Provider-reported prompt and response tokens remain available in live `rag_request` logs.
+
+## Top-k trade-offs
+
+Measured on 2,234 chunks with `Xenova/all-MiniLM-L6-v2` (three-question smoke set; ranking latency excludes query embedding and generation):
+
+| top-k | Relevance density | Answer-support rate | Estimated prompt tokens | Retrieval latency |
+|---:|---:|---:|---:|---:|
+| 3 | 22% | 67% | 529 | 7.57 ms |
+| 5 | 40% | 100% | 866 | 5.96 ms |
+| 10 | 33% | 100% | 1,818 | 4.78 ms |
+| 20 | 40% | 100% | 3,993 | 4.93 ms |
+
+Top 3 missed supporting Pull Request evidence for one question; top 5 was the smallest setting with 100% answer support. Prompt usage grew by 7.5× from top 3 to top 20, while ranking latency stayed within measurement noise because every candidate is scored before slicing. Top 5 therefore remains the default, while 10 and 20 are better treated as future reranker candidate pools than direct prompt input.
+
+## Metadata filtering
+
+`POST /api/chat` accepts an optional filter before vector scoring:
+
+```json
+{
+  "message": "How do I add an MCP server?",
+  "topK": 5,
+  "types": ["documentation", "example_config"]
+}
+```
+
+Supported types are `documentation`, `source`, `issue`, `pull_request`, `cli_help`, and `example_config`. The benchmark compares each example question unfiltered and with these expected filters:
+
+| Question | Suggested filter | Expected trade-off |
+|---|---|---|
+| How do I add an MCP server? | `documentation`, `example_config` | Removes source and conversation noise, but can hide implementation details. |
+| How does the repository chat work? | `documentation`, `source` | Focuses on architecture and implementation; excludes useful historical PR rationale. |
+| What changed in recent pull requests? | `pull_request` | Removes nearly all local-corpus noise; intentionally hides docs that summarize landed changes. |
+
+Filters are therefore optional and caller-selected, never inferred as a hard constraint. An empty filtered candidate set returns the grounded abstention instead of falling back silently to unfiltered results.
+
+Measured at top 5:
+
+| Question | Unfiltered relevant/noise | Filtered relevant/noise | Result |
+|---|---:|---:|---|
+| How do I add an MCP server? | 2/3 | 5/0 | Noise disappeared, but all five filtered chunks came from `README.md`; source diversity needs improvement. |
+| How does the repository chat work? | 2/3 | 3/2 | Filtering helped modestly; two broadly related skill chunks remained. |
+| What changed in recent pull requests? | 2/3 | 5/0 | The `pull_request` filter produced the clearest gain. |
+
+The MCP filter also hid the useful `wiki/wiki/concepts/mcp-registry.md` source because wiki pages are currently classified as `source`. Filtering removed noise overall but can hide useful cross-type evidence, which is why it is not inferred automatically.
+
+## Retrieval trace validation
+
+- GitHub Issues and Pull Requests retain their canonical API-provided URL.
+- Local sources are generated with `GITHUB_SOURCE_REF`. Pass the deployment commit SHA with `flyctl deploy --build-arg "GITHUB_SOURCE_REF=$(git rev-parse HEAD)"` so the linked bytes are the indexed bytes rather than whatever later appears on `main`.
+- The benchmark verifies that each URL matches its indexed path and warns when the index is older than 24 hours. `--check-links` also issues bounded HTTP `HEAD` requests and reports failures without aborting the local evaluation.
+- Retrieved sources remain a retrieval trace, not claim-level citation proof. Users must be able to open the source and verify the answer.
+
+## Degraded retrieval policy
+
+| Scenario | Index/build behavior | Deployment/user behavior |
+|---|---|---|
+| GitHub API unavailable | Continue with the local corpus and a warning. | Chat remains available; Issue/PR questions may abstain. |
+| Invalid GitHub token | Treat the failed GitHub fetch like an outage; never print the token. | Continue with local corpus and expose only a generic corpus warning to operators. |
+| Empty GitHub corpus | Continue if local chunks exist and report zero GitHub documents. | Conversation filters return the grounded abstention. |
+| Empty full corpus | Fail indexing and deployment. | Do not serve a knowingly empty knowledge base. |
+| Stale index | Keep serving for availability, log index age, and alert/rebuild. | Prefer a visible “knowledge updated at” indicator in a future UI. |
+| Embedding model/dimension mismatch | Reject retrieval and require a rebuild. | Return HTTP 500 with a generic retrieval error; log `retrieval_failed` without sensitive input. |
+
+This separates optional remote enrichment from required local grounding. A stale but compatible index is usually better than no service; an incompatible index is unsafe because its similarity scores are meaningless.
+
+## Observability review
+
+The old logs included raw questions, which can contain secrets or private text. Logs now contain question length, top-k, active type filters, retrieved path/type/author/score, retrieval latency, provider token usage, total latency, and failure stage. They do not contain raw prompts, prompt hashes, chunk text, embeddings, tokens, or credentials. Index generation already reports corpus counts; a production metrics backend should aggregate corpus age/counts and retrieval latency without adding user text.
+
+Unsalted prompt hashing was rejected because common questions can be guessed offline. If correlation later becomes necessary, server logs should use a dedicated, rotatable HMAC key; browser logs should remain uncorrelated. Access controls, short retention, and secret scanning/redaction at the log sink remain necessary.
+
+## Production improvement proposal (design only)
+
+1. **Hybrid BM25 + vector search:** union lexical and semantic candidates so exact commands, filenames, and acronyms are not lost when embedding similarity is weak. Retrieve about 20 candidates.
+2. **Metadata pre-filtering:** already implemented for type; extend to path, author, state, branch, and time windows so scoring starts with the right corpus slice.
+3. **Cross-encoder reranking:** jointly score the query and each of the 20 candidates, then send only the best five. This should improve relevance density without paying top-20 prompt cost.
+4. **Content-hash embedding cache:** key embeddings by model plus normalized content hash. Unchanged chunks avoid paid, variable re-embedding and make experiments faster and reproducible.
+5. **Incremental indexing:** update only changed files and GitHub records, while atomically publishing a versioned index. This reduces staleness and rebuild time.
+6. **Retrieval evaluation benchmark:** grow the current three smoke questions into reviewed relevance judgments with Recall@k, MRR/nDCG, filter false-negative rate, abstention accuracy, token usage, and latency gates in CI.
+
+The next implementation should be hybrid top-20 retrieval followed by reranking to five, but only after the benchmark has enough labeled queries to prove the extra complexity and latency improve quality.
+
+## Learning notes
+
+1. The largest answer-quality issue was irrelevant document types crowding a small top-k, especially broad queries about recent Pull Requests.
+2. Metadata pre-filtering gave the biggest targeted gain because it removed noise before scoring without changing embeddings or the LLM.
+3. Hybrid retrieval plus reranking is next: lexical search recovers exact repository vocabulary, while reranking preserves a compact, high-quality prompt.

--- a/lib/indexer.ts
+++ b/lib/indexer.ts
@@ -194,8 +194,9 @@ function classifyPath(path: string): DocumentType {
 
 function localSourceUrl(path: string): string {
 	const repo = process.env.GITHUB_REPOSITORY ?? "jellydn/my-ai-tools";
+	const sourceRef = process.env.GITHUB_SOURCE_REF?.trim() || "main";
 	const encodedPath = path.split("/").map(encodeURIComponent).join("/");
-	return `https://github.com/${repo}/blob/main/${encodedPath}`;
+	return `https://github.com/${repo}/blob/${encodeURIComponent(sourceRef)}/${encodedPath}`;
 }
 
 export function indexRepository(repoRoot: string): Chunk[] {

--- a/lib/retriever.ts
+++ b/lib/retriever.ts
@@ -2,6 +2,7 @@ import { readFile, stat } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type OpenAI from "openai";
+import type { DocumentType } from "./indexer.ts";
 import { createOpenAIClient } from "./openai-client.ts";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -14,7 +15,7 @@ export type Chunk = {
 	path: string;
 	text: string;
 	metadata: {
-		type: string;
+		type: DocumentType;
 		author?: string;
 		url?: string;
 	};
@@ -26,6 +27,11 @@ export type RetrievedChunk = {
 	text: string;
 	metadata: Chunk["metadata"];
 	score: number;
+};
+
+export type RetrievalOptions = {
+	topK: 3 | 5 | 10 | 20;
+	types?: DocumentType[];
 };
 
 export type Index = {
@@ -97,7 +103,26 @@ function cosineSimilarity(a: number[], b: number[]): number {
 		aNorm += aValue * aValue;
 		bNorm += bValue * bValue;
 	}
-	return dot / (Math.sqrt(aNorm) * Math.sqrt(bNorm));
+	const denominator = Math.sqrt(aNorm) * Math.sqrt(bNorm);
+	return denominator === 0 ? 0 : dot / denominator;
+}
+
+export function rankChunks(
+	queryEmbedding: number[],
+	chunks: Chunk[],
+	{ topK, types }: RetrievalOptions,
+): RetrievedChunk[] {
+	const allowedTypes = types?.length ? new Set(types) : null;
+	const candidates = allowedTypes ? chunks.filter((chunk) => allowedTypes.has(chunk.metadata.type)) : chunks;
+	const scored = candidates.map((chunk) => ({
+		path: chunk.path,
+		text: chunk.text,
+		metadata: chunk.metadata,
+		score: cosineSimilarity(queryEmbedding, chunk.embedding),
+	}));
+
+	scored.sort((a, b) => b.score - a.score);
+	return scored.slice(0, topK);
 }
 
 export async function embed(text: string): Promise<number[]> {
@@ -113,9 +138,11 @@ export async function embed(text: string): Promise<number[]> {
 	return response.data[0].embedding;
 }
 
-export async function retrieve(query: string, topK: number): Promise<RetrievedChunk[]> {
+export async function retrieve(query: string, options: RetrievalOptions): Promise<RetrievedChunk[]> {
 	const index = await getIndex();
-	if (index.chunks.length === 0) {
+	const allowedTypes = options.types?.length ? new Set(options.types) : null;
+	const candidates = allowedTypes ? index.chunks.filter((chunk) => allowedTypes.has(chunk.metadata.type)) : index.chunks;
+	if (candidates.length === 0) {
 		return [];
 	}
 
@@ -123,13 +150,5 @@ export async function retrieve(query: string, topK: number): Promise<RetrievedCh
 	if (queryEmbedding.length !== index.chunks[0]?.embedding.length) {
 		throw new Error("Query embedding dimension does not match the repository index; rebuild the index");
 	}
-	const scored = index.chunks.map((chunk) => ({
-		path: chunk.path,
-		text: chunk.text,
-		metadata: chunk.metadata,
-		score: cosineSimilarity(queryEmbedding, chunk.embedding),
-	}));
-
-	scored.sort((a, b) => b.score - a.score);
-	return scored.slice(0, topK);
+	return rankChunks(queryEmbedding, candidates, { ...options, types: undefined });
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"index:browser": "tsx scripts/index-browser.ts",
 		"dev": "tsx server.ts",
 		"start": "tsx server.ts",
+		"eval:retrieval": "tsx scripts/evaluate-retrieval.ts",
 		"test:rag": "tsx --test tests/rag-indexer.test.ts",
 		"typecheck": "tsc --noEmit"
 	},

--- a/public/browser-chat.js
+++ b/public/browser-chat.js
@@ -3,6 +3,7 @@ import { env, pipeline, TextStreamer } from "https://cdn.jsdelivr.net/npm/@huggi
 const EMBEDDING_MODEL = "Xenova/all-MiniLM-L6-v2";
 const LLM_MODEL = "onnx-community/Qwen2.5-Coder-0.5B-Instruct";
 const INDEX_PATH = "/public/index-browser.json";
+const DOCUMENT_TYPES = new Set(["documentation", "source", "issue", "pull_request", "cli_help", "example_config"]);
 
 let indexData = null;
 let extractorPromise = null;
@@ -107,8 +108,10 @@ function dotProduct(a, b) {
 	return sum;
 }
 
-function retrieveTopK(queryEmbedding, chunks, k) {
-	const scored = chunks.map((chunk) => ({ chunk, score: dotProduct(queryEmbedding, chunk.embedding) }));
+function retrieveTopK(queryEmbedding, chunks, k, types = []) {
+	const allowedTypes = types.length > 0 ? new Set(types) : null;
+	const candidates = allowedTypes ? chunks.filter((chunk) => allowedTypes.has(chunk.metadata?.type)) : chunks;
+	const scored = candidates.map((chunk) => ({ chunk, score: dotProduct(queryEmbedding, chunk.embedding) }));
 	scored.sort((a, b) => b.score - a.score);
 	return scored.slice(0, k).map((item) => ({ ...item.chunk, score: item.score }));
 }
@@ -140,8 +143,14 @@ function updateStatus(callbacks, text) {
 	if (callbacks.onStatus) callbacks.onStatus(text);
 }
 
-export async function runBrowserChat(question, callbacks) {
+export async function runBrowserChat(question, callbacks, options = {}) {
 	const startedAt = performance.now();
+	const topK = options.topK === undefined ? 5 : options.topK;
+	const types = options.types === undefined ? [] : options.types;
+	if (![3, 5, 10, 20].includes(topK)) throw new Error("topK must be 3, 5, 10, or 20");
+	if (!Array.isArray(types) || types.length > 6 || types.some((type) => !DOCUMENT_TYPES.has(type))) {
+		throw new Error("types contains an unsupported document type");
+	}
 	updateStatus(callbacks, "Loading index...");
 	const index = await getIndex();
 
@@ -153,7 +162,14 @@ export async function runBrowserChat(question, callbacks) {
 	const queryEmbedding = queryOutput.data;
 
 	updateStatus(callbacks, "Retrieving chunks...");
-	const topChunks = retrieveTopK(queryEmbedding, index.chunks, 5);
+	const retrievalStartedAt = performance.now();
+	const topChunks = retrieveTopK(queryEmbedding, index.chunks, topK, types);
+	const retrievalLatencyMs = Math.round(performance.now() - retrievalStartedAt);
+	if (topChunks.length === 0) {
+		if (callbacks.onToken) callbacks.onToken("This is not documented in the repository.");
+		if (callbacks.onSource) callbacks.onSource([]);
+		return;
+	}
 
 	updateStatus(callbacks, "Loading language model...");
 	const generator = await getGenerator();
@@ -180,13 +196,16 @@ export async function runBrowserChat(question, callbacks) {
 		streamer,
 	});
 	console.info("rag_request", {
-		question,
+		questionLength: question.length,
+		topK,
+		filters: { types },
 		retrievedChunks: topChunks.map((chunk) => ({
 			path: chunk.path,
 			type: chunk.metadata?.type,
 			author: chunk.metadata?.author,
 			score: Number(chunk.score.toFixed(4)),
 		})),
+		retrievalLatencyMs,
 		promptTokens: generator.tokenizer.apply_chat_template(messages, {
 			add_generation_prompt: true,
 			tokenize: true,

--- a/scripts/evaluate-retrieval.ts
+++ b/scripts/evaluate-retrieval.ts
@@ -1,0 +1,199 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pipeline } from "@huggingface/transformers";
+import type { ChunkMetadata, DocumentType } from "../lib/indexer.ts";
+
+const INDEX_PATH = resolve("public/index-browser.json");
+const MODEL = "Xenova/all-MiniLM-L6-v2";
+const TOP_K_VALUES = [3, 5, 10, 20] as const;
+
+type BrowserChunk = {
+	path: string;
+	text: string;
+	metadata: ChunkMetadata;
+	embedding: Float32Array;
+};
+
+type EvaluationCase = {
+	question: string;
+	preferredTypes: DocumentType[];
+	relevantPath: RegExp;
+};
+
+const evaluationCases: EvaluationCase[] = [
+	{
+		question: "How do I add an MCP server?",
+		preferredTypes: ["documentation", "example_config"],
+		relevantPath: /^(README\.md|configs\/mcp-registry\.json|wiki\/wiki\/concepts\/mcp-registry\.md)$/,
+	},
+	{
+		question: "How does the repository chat work?",
+		preferredTypes: ["documentation", "source"],
+		relevantPath: /^(README\.md|docs\/rag-architecture\.md|server\.ts|lib\/retriever\.ts|public\/browser-chat\.js)$/,
+	},
+	{
+		question: "What changed in recent pull requests?",
+		preferredTypes: ["pull_request"],
+		relevantPath: /^pull\/\d+$/,
+	},
+];
+
+function dotProduct(a: Float32Array, b: Float32Array): number {
+	let sum = 0;
+	for (let index = 0; index < a.length; index++) sum += (a[index] ?? 0) * (b[index] ?? 0);
+	return sum;
+}
+
+function rank(query: Float32Array, chunks: BrowserChunk[], topK: number, types: DocumentType[] = []) {
+	const allowedTypes = types.length > 0 ? new Set(types) : null;
+	return chunks
+		.filter((chunk) => !allowedTypes || allowedTypes.has(chunk.metadata.type))
+		.map((chunk) => ({ ...chunk, score: dotProduct(query, chunk.embedding) }))
+		.sort((a, b) => b.score - a.score)
+		.slice(0, topK);
+}
+
+async function loadIndex(): Promise<{
+	generatedAt: string;
+	repository: string;
+	sourceRef: string;
+	chunks: BrowserChunk[];
+}> {
+	const value = JSON.parse(await readFile(INDEX_PATH, "utf-8")) as {
+		schemaVersion: number;
+		generatedAt: string;
+		model: string;
+		repository: string;
+		sourceRef: string;
+		dim: number;
+		chunks: Array<Omit<BrowserChunk, "embedding">>;
+		embeddings: string;
+	};
+	if (
+		value.schemaVersion !== 2 ||
+		value.model !== MODEL ||
+		!value.dim ||
+		!value.chunks.length ||
+		!value.repository ||
+		!value.sourceRef
+	) {
+		throw new Error("Browser index is empty, stale, or uses a different embedding model; run npm run index:browser");
+	}
+	const bytes = Buffer.from(value.embeddings, "base64");
+	if (bytes.byteLength !== value.chunks.length * value.dim * Float32Array.BYTES_PER_ELEMENT) {
+		throw new Error("Browser index embedding dimensions are inconsistent; rebuild the index");
+	}
+	const vectors = new Float32Array(bytes.buffer, bytes.byteOffset, bytes.byteLength / Float32Array.BYTES_PER_ELEMENT);
+	return {
+		generatedAt: value.generatedAt,
+		repository: value.repository,
+		sourceRef: value.sourceRef,
+		chunks: value.chunks.map((chunk, index) => ({
+			...chunk,
+			embedding: vectors.subarray(index * value.dim, (index + 1) * value.dim),
+		})),
+	};
+}
+
+function estimatedPromptTokens(chunks: BrowserChunk[]): number {
+	return Math.ceil(chunks.reduce((total, chunk) => total + chunk.path.length + chunk.text.length, 0) / 4);
+}
+
+async function validateLinks(chunks: BrowserChunk[], repository: string, sourceRef: string, checkLinks: boolean) {
+	const unique = [...new Map(chunks.map((chunk) => [chunk.metadata.url, chunk])).values()];
+	let structurallyValid = 0;
+	let opened = 0;
+	for (const chunk of unique) {
+		const url = chunk.metadata.url;
+		const expectedPrefix = `https://github.com/${repository}/blob/${encodeURIComponent(sourceRef)}/`;
+		const sourceMatches =
+			chunk.metadata.type === "issue" || chunk.metadata.type === "pull_request"
+				? url?.startsWith(`https://github.com/${repository}/`) && url.endsWith(`/${chunk.path}`)
+				: url?.startsWith(expectedPrefix) && url.endsWith(`/${chunk.path}`);
+		if (sourceMatches) structurallyValid++;
+		if (checkLinks && url) {
+			try {
+				const response = await fetch(url, { method: "HEAD", signal: AbortSignal.timeout(5000) });
+				if (response.ok) opened++;
+			} catch {
+				// Network failures are reported in the summary instead of aborting the benchmark.
+			}
+		}
+	}
+	return { checked: unique.length, structurallyValid, opened: checkLinks ? opened : null };
+}
+
+async function main() {
+	const index = await loadIndex();
+	const indexAgeHours = (Date.now() - Date.parse(index.generatedAt)) / 3_600_000;
+	const extractor = await pipeline("feature-extraction", MODEL);
+	const queryVectors = new Map<string, Float32Array>();
+	for (const evaluationCase of evaluationCases) {
+		const output = await extractor(evaluationCase.question, { pooling: "mean", normalize: true });
+		queryVectors.set(evaluationCase.question, output.data as Float32Array);
+	}
+
+	console.log("# Retrieval top-k comparison\n");
+	console.log(
+		"| top-k | relevance density | answer-support rate | estimated prompt tokens | retrieval latency |\n|---:|---:|---:|---:|---:|",
+	);
+	for (const topK of TOP_K_VALUES) {
+		let relevant = 0;
+		let supported = 0;
+		let tokens = 0;
+		const startedAt = performance.now();
+		for (const evaluationCase of evaluationCases) {
+			const ranked = rank(queryVectors.get(evaluationCase.question)!, index.chunks, topK);
+			const relevantCount = ranked.filter((chunk) => evaluationCase.relevantPath.test(chunk.path)).length;
+			relevant += relevantCount;
+			supported += Number(relevantCount > 0);
+			tokens += estimatedPromptTokens(ranked);
+		}
+		const latency = performance.now() - startedAt;
+		console.log(
+			`| ${topK} | ${((relevant / (evaluationCases.length * topK)) * 100).toFixed(0)}% | ${((supported / evaluationCases.length) * 100).toFixed(0)}% | ${Math.round(tokens / evaluationCases.length)} | ${(latency / evaluationCases.length).toFixed(2)} ms |`,
+		);
+	}
+
+	console.log("\n# Metadata filtering comparison\n");
+	console.log("| question | mode | relevant | noise | sources |\n|---|---|---:|---:|---|");
+	const traceChunks: BrowserChunk[] = [];
+	for (const evaluationCase of evaluationCases) {
+		for (const [mode, types] of [
+			["unfiltered", []],
+			["filtered", evaluationCase.preferredTypes],
+		] as const) {
+			const ranked = rank(queryVectors.get(evaluationCase.question)!, index.chunks, 5, [...types]);
+			if (mode === "unfiltered") traceChunks.push(...ranked);
+			const relevant = ranked.filter((chunk) => evaluationCase.relevantPath.test(chunk.path)).length;
+			const noise = ranked.filter((chunk) => !evaluationCase.relevantPath.test(chunk.path)).length;
+			console.log(
+				`| ${evaluationCase.question} | ${mode} | ${relevant}/${ranked.length} | ${noise}/${ranked.length} | ${ranked.map((chunk) => `\`${chunk.path}\``).join(", ")} |`,
+			);
+		}
+	}
+
+	const links = await validateLinks(
+		traceChunks,
+		index.repository,
+		index.sourceRef,
+		process.argv.includes("--check-links"),
+	);
+	console.log("\n# Retrieval trace\n");
+	console.log(`- Index generated: ${index.generatedAt} (${indexAgeHours.toFixed(1)} hours old)`);
+	console.log(`- Indexed revision: ${index.repository}@${index.sourceRef}`);
+	console.log(`- Canonical URL/path checks: ${links.structurallyValid}/${links.checked}`);
+	console.log(
+		`- HTTP link checks: ${links.opened === null ? "not run (pass --check-links)" : `${links.opened}/${links.checked}`}`,
+	);
+	if (indexAgeHours > 24)
+		console.log("- Warning: index is older than 24 hours; rebuild before using results for release decisions.");
+	console.log(
+		"\nAnswer-support rate is a retrieval-only proxy: it means at least one human-labeled source was present. It is not an LLM judge score.",
+	);
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/scripts/index-browser.ts
+++ b/scripts/index-browser.ts
@@ -11,7 +11,7 @@ const PUBLIC_DIR = resolve(REPO_ROOT, "public");
 const INDEX_PATH = resolve(PUBLIC_DIR, "index-browser.json");
 
 const EMBEDDING_MODEL = "Xenova/all-MiniLM-L6-v2";
-const EMBEDDING_BATCH_SIZE = 32;
+const EMBEDDING_BATCH_SIZE = 4;
 
 async function createEmbeddings(texts: string[]): Promise<number[][]> {
 	const extractor = await pipeline("feature-extraction", EMBEDDING_MODEL);
@@ -65,6 +65,8 @@ async function main() {
 			schemaVersion: 2,
 			generatedAt: new Date().toISOString(),
 			model: EMBEDDING_MODEL,
+			repository: process.env.GITHUB_REPOSITORY ?? "jellydn/my-ai-tools",
+			sourceRef: process.env.GITHUB_SOURCE_REF?.trim() || "main",
 			dim,
 			chunks: chunks.map((chunk) => ({
 				path: chunk.path,

--- a/scripts/index-repo.ts
+++ b/scripts/index-repo.ts
@@ -62,6 +62,8 @@ async function main() {
 			schemaVersion: 2,
 			generatedAt: new Date().toISOString(),
 			model: EMBEDDING_MODEL,
+			repository: process.env.GITHUB_REPOSITORY ?? "jellydn/my-ai-tools",
+			sourceRef: process.env.GITHUB_SOURCE_REF?.trim() || "main",
 			chunks: indexedChunks,
 		}),
 		"utf-8",

--- a/server.ts
+++ b/server.ts
@@ -59,8 +59,11 @@ if (!process.env.OPENAI_API_KEY) {
 
 const openai = createOpenAIClient();
 
+const documentTypeSchema = z.enum(["documentation", "source", "issue", "pull_request", "cli_help", "example_config"]);
 const chatRequestSchema = z.object({
 	message: z.string().min(1).max(4000),
+	topK: z.union([z.literal(3), z.literal(5), z.literal(10), z.literal(20)]).default(5),
+	types: z.array(documentTypeSchema).max(6).optional(),
 });
 
 app.use("/data/*", async (c) => c.text("Forbidden", 403));
@@ -78,16 +81,20 @@ app.post("/api/chat", rateLimitMiddleware, async (c) => {
 		return c.json({ error: "Invalid request body" }, 400);
 	}
 
-	const { message } = parsed.data;
+	const { message, topK, types } = parsed.data;
 	let chunks: RetrievedChunk[];
+	const retrievalStartedAt = performance.now();
 	try {
-		chunks = await retrieve(message, 5);
+		chunks = await retrieve(message, { topK, types });
 	} catch (error) {
 		console.error(
 			JSON.stringify({
 				event: "rag_request",
-				question: message,
+				questionLength: message.length,
+				topK,
+				filters: { types: types ?? [] },
 				retrievedChunks: [],
+				retrievalLatencyMs: Math.round(performance.now() - retrievalStartedAt),
 				latencyMs: Math.round(performance.now() - startedAt),
 				error: "retrieval_failed",
 			}),
@@ -102,8 +109,11 @@ app.post("/api/chat", rateLimitMiddleware, async (c) => {
 		console.log(
 			JSON.stringify({
 				event: "rag_request",
-				question: message,
+				questionLength: message.length,
+				topK,
+				filters: { types: types ?? [] },
 				retrievedChunks: [],
+				retrievalLatencyMs: Math.round(performance.now() - retrievalStartedAt),
 				promptTokens: 0,
 				responseTokens: 0,
 				latencyMs: Math.round(performance.now() - startedAt),
@@ -133,12 +143,15 @@ app.post("/api/chat", rateLimitMiddleware, async (c) => {
 		console.error(
 			JSON.stringify({
 				event: "rag_request",
-				question: message,
+				questionLength: message.length,
+				topK,
+				filters: { types: types ?? [] },
 				retrievedChunks: chunks.map((chunk) => ({
 					path: chunk.path,
 					type: chunk.metadata.type,
 					score: Number(chunk.score.toFixed(4)),
 				})),
+				retrievalLatencyMs: Math.round(performance.now() - retrievalStartedAt),
 				latencyMs: Math.round(performance.now() - startedAt),
 				error: "generation_unavailable",
 			}),
@@ -176,13 +189,16 @@ app.post("/api/chat", rateLimitMiddleware, async (c) => {
 			console.log(
 				JSON.stringify({
 					event: "rag_request",
-					question: message,
+					questionLength: message.length,
+					topK,
+					filters: { types: types ?? [] },
 					retrievedChunks: chunks.map((chunk) => ({
 						path: chunk.path,
 						type: chunk.metadata.type,
 						author: chunk.metadata.author,
 						score: Number(chunk.score.toFixed(4)),
 					})),
+					retrievalLatencyMs: Math.round(performance.now() - retrievalStartedAt),
 					promptTokens,
 					responseTokens,
 					latencyMs: Math.round(performance.now() - startedAt),

--- a/tests/rag-indexer.test.ts
+++ b/tests/rag-indexer.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import test from "node:test";
 import { CHUNK_OVERLAP, chunkMarkdown, chunkText, indexRepository, MAX_CHUNK_SIZE } from "../lib/indexer.ts";
 import { buildContextMessage, RAG_SYSTEM_PROMPT } from "../lib/rag-prompt.ts";
-import { validateIndex } from "../lib/retriever.ts";
+import { type Chunk, rankChunks, validateIndex } from "../lib/retriever.ts";
 
 test("chunkText enforces the target size and overlap", () => {
 	const text = Array.from({ length: 2400 }, (_, index) => String.fromCharCode(33 + (index % 90))).join("");
@@ -69,8 +69,29 @@ test("server index validation rejects stale schemas and dimensions", () => {
 	);
 });
 
+test("retrieval supports top-k and metadata pre-filtering", () => {
+	const chunks: Chunk[] = [
+		{ path: "docs/guide.md", text: "guide", metadata: { type: "documentation" }, embedding: [1, 0] },
+		{ path: "server.ts", text: "server", metadata: { type: "source" }, embedding: [0.9, 0.1] },
+		{ path: "pull/315", text: "pull", metadata: { type: "pull_request" }, embedding: [0.8, 0.2] },
+		{ path: "issues/1", text: "issue", metadata: { type: "issue" }, embedding: [0.7, 0.3] },
+	];
+
+	assert.deepEqual(
+		rankChunks([1, 0], chunks, { topK: 3 }).map((chunk) => chunk.path),
+		["docs/guide.md", "server.ts", "pull/315"],
+	);
+	assert.deepEqual(
+		rankChunks([1, 0], chunks, { topK: 5, types: ["pull_request"] }).map((chunk) => chunk.path),
+		["pull/315"],
+	);
+	assert.equal(rankChunks([0, 0], chunks, { topK: 3 })[0]?.score, 0);
+});
+
 test("indexRepository classifies documentation, CLI help, configs, and source", () => {
 	const root = mkdtempSync(join(tmpdir(), "rag-indexer-"));
+	const originalSourceRef = process.env.GITHUB_SOURCE_REF;
+	process.env.GITHUB_SOURCE_REF = "abc123";
 	try {
 		mkdirSync(join(root, "docs"));
 		mkdirSync(join(root, "configs"));
@@ -88,7 +109,10 @@ test("indexRepository classifies documentation, CLI help, configs, and source", 
 		assert.equal(typesByPath["configs/agent.toml"], "example_config");
 		assert.equal(typesByPath["cli.sh"], "cli_help");
 		assert.equal(typesByPath["server.ts"], "source");
+		assert.match(chunks.find((chunk) => chunk.path === "README.md")?.metadata.url ?? "", /blob\/abc123\/README\.md$/);
 	} finally {
+		if (originalSourceRef === undefined) delete process.env.GITHUB_SOURCE_REF;
+		else process.env.GITHUB_SOURCE_REF = originalSourceRef;
 		rmSync(root, { recursive: true, force: true });
 	}
 });


### PR DESCRIPTION
## Summary

Stacks on #315 and evaluates retrieval quality without changing the answer model.

## What changed

- supports `topK` 3, 5, 10, or 20 in server and browser retrieval
- adds document-type pre-filtering for documentation, source, Issues, Pull Requests, CLI help, and example configs
- supports commit-pinned local retrieval-trace URLs through `GITHUB_SOURCE_REF`
- removes raw questions and deterministic prompt hashes from diagnostics while adding retrieval settings and retrieval latency
- lowers browser index embedding batches to avoid peak-memory failures
- adds a reproducible real-corpus retrieval benchmark and Day 11 report

## Results

The 2,234-chunk smoke benchmark found:

| top-k | relevance density | answer support | estimated prompt tokens |
|---:|---:|---:|---:|
| 3 | 22% | 67% | 529 |
| 5 | 40% | 100% | 866 |
| 10 | 33% | 100% | 1,818 |
| 20 | 40% | 100% | 3,993 |

Top 5 remains the default. Type filtering improved relevant/noise results from 2/3 to 5/0 for MCP and Pull Request questions, while also exposing duplicate README chunks and a useful wiki source hidden by filtering.

## Validation

- `npm run typecheck`
- `npm run test:rag` — 8/8 passing
- `npx biome check` on touched TS/JS/JSON files
- `bash -n cli.sh generate.sh`
- `npm run index:browser` — 2,234 chunks; reduced batches avoided the prior OOM
- `npm run eval:retrieval -- --check-links`

`bats` is unavailable in the current orb, so the Bats suite could not be run locally.

## Deliverables

See `docs/rag-retrieval-quality.md` for the top-k comparison, metadata filtering results, trace validation policy, degraded-retrieval decisions, production improvement proposal, and three learning notes.