### PR TITLE
docs: require skill evals before publishing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,8 +50,9 @@ Open an issue or reach out via support channels listed in README.md.
 
 1. **Create skill directory**: Create a new directory under `.claude/skills/{skill-name}/`
 2. **Create SKILL.md file**: Add `SKILL.md` with skill frontmatter and content
-3. **Update skill-rules.json**: Add triggers and keywords for your new skill
-4. **Document**: Add skill to `skills/README.md` if it exists
+3. **Write evals**: Add 3-5 prompts that prove the skill works, including at least one negative case. See [`docs/skill-evals.md`](docs/skill-evals.md).
+4. **Update skill-rules.json**: Add triggers and keywords for your new skill
+5. **Document**: Add skill to `skills/README.md` if it exists
 
 ### Skill Frontmatter Format
 
@@ -127,7 +128,7 @@ Edit `.claude/hooks/skill-rules.json` to:
 
 Before submitting a PR or commit:
 
-1. **Test skill evaluation**: Run `/onboard <test>` to verify skills activate
+1. **Test skill evaluation**: Run the eval prompts for the new skill and confirm the intended skill triggers on happy paths and stays quiet on near-miss prompts.
 2. **Test hooks**: Edit a file on main branch to verify branch protection
 3. **Test agents**: Run `/code-reviewer` to verify review quality
 4. **Test commands**: Try new commands in a test directory

--- a/docs/skill-evals.md
+++ b/docs/skill-evals.md
@@ -1,0 +1,76 @@
+# Skill Evals
+
+Before publishing a new skill, define a few evals that prove it works.
+
+## Why this matters
+
+A skill can sound correct in one demo and still fail on:
+
+- near-miss prompts
+- ambiguous wording
+- edge cases the author did not test
+- prompts that should *not* trigger the skill
+
+If the skill is public, it should ship with a tiny eval set.
+
+## Minimal eval set
+
+For each skill, write at least:
+
+- 3 happy-path prompts that should trigger the skill
+- 1-2 near-miss prompts that should not trigger it
+- 1 edge-case prompt that exercises a boundary or failure mode
+
+## What to record
+
+For each eval, capture:
+
+- the prompt
+- whether the skill should trigger
+- the expected behavior in plain English
+- any pass/fail notes from manual review
+
+## Template
+
+```markdown
+# Skill evals: <skill-name>
+
+## Goal
+
+What capability is this skill supposed to provide?
+
+## Happy path prompts
+
+1. Prompt: ...
+   Expected: ...
+
+2. Prompt: ...
+   Expected: ...
+
+3. Prompt: ...
+   Expected: ...
+
+## Near-miss prompts
+
+1. Prompt: ...
+   Expected: skill should not trigger / should ask for clarification / should route elsewhere
+
+## Edge cases
+
+1. Prompt: ...
+   Expected: ...
+
+## Pass criteria
+
+- The right skill triggers on the intended prompts
+- The skill stays in scope on ambiguous prompts
+- Failure cases are understood and documented
+```
+
+## Review checklist
+
+- [ ] The skill has eval prompts, not just a description
+- [ ] At least one negative case is included
+- [ ] Expected outputs are specific enough to review manually
+- [ ] The evals were run before the skill was published
+- [ ] Any failures led to an update in the skill or its trigger rules

--- a/docs/skill-evals.md
+++ b/docs/skill-evals.md
@@ -4,22 +4,29 @@ Before publishing a new skill, define a few evals that prove it works.
 
 ## Why this matters
 
-A skill can sound correct in one demo and still fail on:
+A skill can look correct in one demo and still fail on:
 
 - near-miss prompts
 - ambiguous wording
 - edge cases the author did not test
 - prompts that should *not* trigger the skill
 
-If the skill is public, it should ship with a tiny eval set.
+If the skill is public, it should ship with a tiny eval set *and* a simple process for comparing the skill against a baseline.
 
 ## Minimal eval set
 
-For each skill, write at least:
+Start small. For each skill, write at least:
 
-- 3 happy-path prompts that should trigger the skill
+- 2-3 happy-path prompts that should trigger the skill
 - 1-2 near-miss prompts that should not trigger it
 - 1 edge-case prompt that exercises a boundary or failure mode
+
+Vary the wording so the prompts feel like real users:
+
+- casual vs precise
+- short vs detailed
+- vague vs specific
+- with and without file paths or other context
 
 ## What to record
 
@@ -30,47 +37,78 @@ For each eval, capture:
 - the expected behavior in plain English
 - any pass/fail notes from manual review
 
-## Template
+Store test cases in `evals/evals.json` inside the skill directory.
+
+## Recommended structure
 
 ```markdown
-# Skill evals: <skill-name>
-
-## Goal
-
-What capability is this skill supposed to provide?
-
-## Happy path prompts
-
-1. Prompt: ...
-   Expected: ...
-
-2. Prompt: ...
-   Expected: ...
-
-3. Prompt: ...
-   Expected: ...
-
-## Near-miss prompts
-
-1. Prompt: ...
-   Expected: skill should not trigger / should ask for clarification / should route elsewhere
-
-## Edge cases
-
-1. Prompt: ...
-   Expected: ...
-
-## Pass criteria
-
-- The right skill triggers on the intended prompts
-- The skill stays in scope on ambiguous prompts
-- Failure cases are understood and documented
+skill-name/
+├── SKILL.md
+└── evals/
+    └── evals.json
 ```
+
+A test case should usually include:
+
+- `prompt`: realistic user input
+- `expected_output`: human-readable success criteria
+- `files` (optional): input files the skill needs
+- `assertions` (optional at first): concrete checks added after the first run
+
+## Evaluation loop
+
+A practical loop is:
+
+1. Run the test case *with the skill*.
+2. Run the same test case *without the skill* or against a previous version.
+3. Compare the outputs, timing, and token cost.
+4. Add assertions after you see the first round of results.
+5. Review the outputs with a human.
+6. Improve the skill, then rerun the evals in a new iteration.
+
+## Assertions
+
+Use assertions for things you can check objectively:
+
+- output is valid JSON
+- a file exists
+- a chart has the expected number of bars
+- a report includes a countable item
+
+Avoid assertions that are too vague or too brittle:
+
+- "the output is good"
+- exact phrasing when wording can vary
+
+If you need to check style, usefulness, or whether the output actually answers the user, keep that for human review.
+
+## Human review
+
+A human reviewer should look for things the assertions miss:
+
+- technically correct but unhelpful outputs
+- missing context
+- poor organization
+- flaky behavior across runs
+
+Write feedback as something actionable, not just "looks bad".
+
+## What to optimize
+
+When iterating on a skill, look for three signals:
+
+- failed assertions → missing steps or broken instructions
+- consistent human complaints → weak structure or poor usefulness
+- time/token outliers → unnecessary work that should be removed or bundled
+
+If every run keeps recreating the same helper logic, consider moving it into the skill's `scripts/` directory.
 
 ## Review checklist
 
 - [ ] The skill has eval prompts, not just a description
 - [ ] At least one negative case is included
+- [ ] The prompts are realistic and varied
 - [ ] Expected outputs are specific enough to review manually
 - [ ] The evals were run before the skill was published
 - [ ] Any failures led to an update in the skill or its trigger rules
+- [ ] The skill was compared against a baseline or previous version

--- a/skills/adr/SKILL.md
+++ b/skills/adr/SKILL.md
@@ -12,6 +12,18 @@ metadata:
 
 # Architecture Decision Records (ADR)
 
+## What
+
+- Record architecture decisions with ADRs — captures why, alternatives considered, and consequences
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 Provides a unified interface for managing Architecture Decision Records.
 
 ## Usage

--- a/skills/adr/evals/evals.json
+++ b/skills/adr/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "adr",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Write an ADR for choosing PostgreSQL over SQLite for the production app.",
+      "should_trigger": true,
+      "expected_behavior": "Produces an ADR that records the decision, alternatives considered, and consequences."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Capture the decision to keep the current cache strategy and note why we are not changing it.",
+      "should_trigger": true,
+      "expected_behavior": "Produces an ADR-style decision record with rationale and trade-offs."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Summarize the database options in one paragraph.",
+      "should_trigger": false,
+      "expected_behavior": "This is a general summary request, not an architecture decision record."
+    },
+    {
+      "id": "case-4",
+      "prompt": "We already decided on the API gateway last week. Create an ADR that reflects the final choice and the rejected options.",
+      "should_trigger": true,
+      "expected_behavior": "Handles an already-made decision and still documents context, alternatives, and consequences."
+    }
+  ]
+}

--- a/skills/blindspot-pass/SKILL.md
+++ b/skills/blindspot-pass/SKILL.md
@@ -9,6 +9,18 @@ user-invocable: true
 
 # Blind Spot Pass
 
+## What
+
+- Find unknown unknowns before starting implementation — searches git history, patterns, and architecture for hidden gotchas
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 ## When to Use
 
 Use this skill **before starting implementation** when:

--- a/skills/blindspot-pass/evals/evals.json
+++ b/skills/blindspot-pass/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "blindspot-pass",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Before refactoring the auth flow, find hidden risks and unknown unknowns.",
+      "should_trigger": true,
+      "expected_behavior": "Surfaces likely blind spots, edge cases, and architecture gotchas before implementation."
+    },
+    {
+      "id": "case-2",
+      "prompt": "What should I check before shipping this feature so I do not miss anything obvious?",
+      "should_trigger": true,
+      "expected_behavior": "Produces a risk-oriented blindspot pass focused on unknown unknowns and hidden assumptions."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Give me a high-level project status update.",
+      "should_trigger": false,
+      "expected_behavior": "This is not a blindspot discovery request."
+    },
+    {
+      "id": "case-4",
+      "prompt": "Review this tiny change where the obvious risk is already known; still look for less obvious gotchas.",
+      "should_trigger": true,
+      "expected_behavior": "Looks beyond the obvious issue and searches for secondary risks and missing context."
+    }
+  ]
+}

--- a/skills/capability-experiments/SKILL.md
+++ b/skills/capability-experiments/SKILL.md
@@ -9,6 +9,18 @@ user-invocable: true
 
 # Capability Experiments
 
+## What
+
+- Experiment with model capabilities — HTML reports, embedded questionnaires, proactive research, multi-step reasoning
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 ## When to Use
 
 Use this skill when:

--- a/skills/capability-experiments/evals/evals.json
+++ b/skills/capability-experiments/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "capability-experiments",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Design an experiment to test whether the model can follow multi-step reasoning instructions and summarize the result in an HTML report.",
+      "should_trigger": true,
+      "expected_behavior": "Produces an experiment plan and report structure for measuring capability."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Run a small questionnaire to compare two prompt styles for robustness.",
+      "should_trigger": true,
+      "expected_behavior": "Creates a structured capability experiment with measurable prompts and comparison points."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Explain how LLMs work at a high level.",
+      "should_trigger": false,
+      "expected_behavior": "This is an explanation request, not a capability experiment."
+    },
+    {
+      "id": "case-4",
+      "prompt": "Create a multi-step experiment that asks the model to search first, then reason, then report failures.",
+      "should_trigger": true,
+      "expected_behavior": "Exercises staged evaluation and records where the model succeeds or fails."
+    }
+  ]
+}

--- a/skills/code-quality-review/SKILL.md
+++ b/skills/code-quality-review/SKILL.md
@@ -11,6 +11,18 @@ metadata:
 
 # Code Quality Review
 
+## What
+
+- Run an extremely strict maintainability and structural code quality review — flags abstraction issues, spaghetti growth, and boundary leaks
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 Use this skill for an unusually strict review focused on implementation quality, maintainability, abstraction quality, and codebase health.
 
 Above all, this skill should push the reviewer to be **ambitious** about code structure. Actively search for "code judo" moves: restructurings that preserve behavior while making the implementation dramatically simpler, smaller, more direct, and more elegant. Surface-level cleanup notes are useful but secondary — the real goal is structural simplification.

--- a/skills/code-quality-review/evals/evals.json
+++ b/skills/code-quality-review/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "code-quality-review",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Review this refactor for structural issues, abstraction leaks, and overly complex boundaries.",
+      "should_trigger": true,
+      "expected_behavior": "Performs a strict architecture and maintainability review."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Audit the implementation for code judo opportunities and delete unnecessary layers.",
+      "should_trigger": true,
+      "expected_behavior": "Identifies simplification opportunities and structural smell."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Check if the code has syntax errors.",
+      "should_trigger": false,
+      "expected_behavior": "This is a linting/basic validation request, not a structural review."
+    },
+    {
+      "id": "case-4",
+      "prompt": "The feature works, but the file is growing fast. Review whether the design is becoming spaghetti.",
+      "should_trigger": true,
+      "expected_behavior": "Flags design drift, file growth, and abstraction issues."
+    }
+  ]
+}

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -10,6 +10,18 @@ metadata:
   workflow: code-quality
 ---
 
+## What
+
+- Review the diff between `HEAD` and a fixed point the user supplies along two axes: Conventions and Intent.
+
+## Why
+
+- This catches local code-quality issues and spec mismatches before they reach merge.
+
+## How
+
+- Pin the fixed point, gather repo standards and intent context, run both review axes in parallel, and aggregate the findings.
+
 Two-axis review of the diff between `HEAD` and a fixed point the user supplies:
 
 - **Conventions** — does the code follow this repo's documented coding standards and Tidy First practices?

--- a/skills/code-review/evals/evals.json
+++ b/skills/code-review/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "code-review",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Review the diff since main and check both conventions and intent.",
+      "should_trigger": true,
+      "expected_behavior": "Separately evaluates repo conventions and whether the change matches its stated purpose."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Review this PR against HEAD~3 and call out any coding-standard or behavior mismatches.",
+      "should_trigger": true,
+      "expected_behavior": "Runs a two-axis review against a fixed point."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Can you summarize the latest branch for me?",
+      "should_trigger": false,
+      "expected_behavior": "This is a summary request, not a code review."
+    },
+    {
+      "id": "case-4",
+      "prompt": "Review the diff since commit abc123, but ignore a documented implementation-log deviation.",
+      "should_trigger": true,
+      "expected_behavior": "Respects documented deviations while reviewing conventions and intent."
+    }
+  ]
+}

--- a/skills/codemap/SKILL.md
+++ b/skills/codemap/SKILL.md
@@ -12,6 +12,18 @@ metadata:
 
 # Codemap
 
+## What
+
+- Map codebase structure with parallel analysis — produces 7 documents about architecture, concerns, and conventions
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 ## What I do
 
 Analyze your entire codebase and create 7 comprehensive documentation files in `.planning/codebase/`:

--- a/skills/codemap/evals/evals.json
+++ b/skills/codemap/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "codemap",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Map the architecture of this repo and explain the main boundaries and responsibilities.",
+      "should_trigger": true,
+      "expected_behavior": "Produces a structured code map of the repository."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Create the set of docs that describe the codebase concerns and conventions.",
+      "should_trigger": true,
+      "expected_behavior": "Generates an overview of codebase structure and design themes."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Find the function that formats dates.",
+      "should_trigger": false,
+      "expected_behavior": "This is a targeted search request, not a full codemap."
+    },
+    {
+      "id": "case-4",
+      "prompt": "I need a quick map of the repo before making changes in three different areas.",
+      "should_trigger": true,
+      "expected_behavior": "Builds an architecture-level orientation map across areas of the codebase."
+    }
+  ]
+}

--- a/skills/commit-atomic/SKILL.md
+++ b/skills/commit-atomic/SKILL.md
@@ -12,6 +12,18 @@ metadata:
 
 # Atomic Commit with Logical Grouping
 
+## What
+
+- Group staged changes into atomic commits with commitizen convention
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 Create atomic commits by logically grouping changes following the commitizen/conventional commits convention. Each commit should represent one logical change with a clear, informative message explaining the **what** and **why**.
 
 ## Usage

--- a/skills/commit-atomic/evals/evals.json
+++ b/skills/commit-atomic/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "commit-atomic",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Split the staged changes into atomic commits with clear commitizen-style messages.",
+      "should_trigger": true,
+      "expected_behavior": "Groups related changes into separate commits."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Create logical commits from my current staged diff and keep each commit focused.",
+      "should_trigger": true,
+      "expected_behavior": "Produces atomic commits aligned to change intent."
+    },
+    {
+      "id": "case-3",
+      "prompt": "What is the current git status?",
+      "should_trigger": false,
+      "expected_behavior": "This is just a status request, not a commit-splitting request."
+    },
+    {
+      "id": "case-4",
+      "prompt": "The diff mixes docs, tests, and code. Split it so each commit is independently reviewable.",
+      "should_trigger": true,
+      "expected_behavior": "Separates mixed concerns into coherent commits."
+    }
+  ]
+}

--- a/skills/context-discovery/SKILL.md
+++ b/skills/context-discovery/SKILL.md
@@ -9,6 +9,18 @@ user-invocable: true
 
 # Context Discovery
 
+## What
+
+- Discover context using MCP tools — fff, sem, ctx, qmd, codebase-memory-mcp for codebase understanding
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 ## When to Use
 
 Use this skill **before and during implementation** when:

--- a/skills/context-discovery/evals/evals.json
+++ b/skills/context-discovery/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "context-discovery",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Use the available MCP tools to discover the repo context before changing the feature.",
+      "should_trigger": true,
+      "expected_behavior": "Collects relevant repository and tool context using discovery tools."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Find the project conventions, nearby patterns, and any relevant docs.",
+      "should_trigger": true,
+      "expected_behavior": "Performs context discovery across code and documentation."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Write the feature implementation now.",
+      "should_trigger": false,
+      "expected_behavior": "This asks for implementation, not discovery."
+    },
+    {
+      "id": "case-4",
+      "prompt": "I only know the file path; discover the surrounding architecture and conventions first.",
+      "should_trigger": true,
+      "expected_behavior": "Starts from a narrow clue and expands to useful project context."
+    }
+  ]
+}

--- a/skills/doc-search/SKILL.md
+++ b/skills/doc-search/SKILL.md
@@ -9,6 +9,18 @@ user-invocable: true
 
 # Documentation Search
 
+## What
+
+- Search project documentation — ADRs, wiki entries, conventions via ripgrep, qmd, fff, and ctx
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 ## When to Use
 
 Use this skill when:

--- a/skills/doc-search/evals/evals.json
+++ b/skills/doc-search/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "doc-search",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Search the docs for the repository convention on environment variables.",
+      "should_trigger": true,
+      "expected_behavior": "Finds relevant documentation passages and conventions."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Look through the project docs for guidance on deployment or handoff workflows.",
+      "should_trigger": true,
+      "expected_behavior": "Searches docs and surfaces the relevant references."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Change the docs so they mention deployment.",
+      "should_trigger": false,
+      "expected_behavior": "This is a docs-edit request, not search."
+    },
+    {
+      "id": "case-4",
+      "prompt": "I vaguely remember a rule about code review in the docs; find it.",
+      "should_trigger": true,
+      "expected_behavior": "Uses documentation search to recover a remembered rule."
+    }
+  ]
+}

--- a/skills/docs-update/SKILL.md
+++ b/skills/docs-update/SKILL.md
@@ -13,6 +13,18 @@ metadata:
 
 # Documentation Bot
 
+## What
+
+- Update docs when code changes — reviews commits and syncs user-facing documentation
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 Automatically review code changes and update user-facing documentation to keep it synchronized with the codebase. Works across documentation platforms (Mintlify, Docusaurus, GitBook, Fumadocs, etc.) and supports both monorepo and multi-repo setups.
 
 ## Workflow

--- a/skills/docs-update/evals/evals.json
+++ b/skills/docs-update/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "docs-update",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "The code changed; update the user-facing docs to match.",
+      "should_trigger": true,
+      "expected_behavior": "Synchronizes documentation with the code change."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Review the latest commit and patch any docs that are now stale.",
+      "should_trigger": true,
+      "expected_behavior": "Finds documentation drift and updates the docs."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Write a new feature spec from scratch.",
+      "should_trigger": false,
+      "expected_behavior": "This is spec writing, not doc sync after code changes."
+    },
+    {
+      "id": "case-4",
+      "prompt": "The API response shape changed; update the examples and the README.",
+      "should_trigger": true,
+      "expected_behavior": "Covers docs that need to reflect changed behavior and examples."
+    }
+  ]
+}

--- a/skills/draft-pull-request/evals/evals.json
+++ b/skills/draft-pull-request/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "draft-pull-request",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Create a draft pull request for the current branch with a What / Why / How description.",
+      "should_trigger": true,
+      "expected_behavior": "Creates a draft PR using the structured template."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Open a draft PR and derive the title from the branch if I do not provide one.",
+      "should_trigger": true,
+      "expected_behavior": "Follows the draft PR workflow and chooses an appropriate title."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Can you review this branch before I open a PR?",
+      "should_trigger": false,
+      "expected_behavior": "This is a review request, not PR creation."
+    },
+    {
+      "id": "case-4",
+      "prompt": "Make a draft PR even though I only gave you a short title and no body.",
+      "should_trigger": true,
+      "expected_behavior": "Creates the PR and fills in the description from branch and diff context."
+    }
+  ]
+}

--- a/skills/git-context/SKILL.md
+++ b/skills/git-context/SKILL.md
@@ -9,6 +9,18 @@ user-invocable: true
 
 # Git Context
 
+## What
+
+- Search git history for context — commit messages, blame, related changes, impact analysis
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 ## When to Use
 
 Use this skill when:

--- a/skills/git-context/evals/evals.json
+++ b/skills/git-context/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "git-context",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Search git history for a similar bug fix and tell me how it was handled.",
+      "should_trigger": true,
+      "expected_behavior": "Uses git history, commits, or blame to find related context."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Find the commit that introduced this pattern and explain why.",
+      "should_trigger": true,
+      "expected_behavior": "Surfaces relevant historical context and intent."
+    },
+    {
+      "id": "case-3",
+      "prompt": "What branch am I on?",
+      "should_trigger": false,
+      "expected_behavior": "This is a simple git status request, not context mining."
+    },
+    {
+      "id": "case-4",
+      "prompt": "Before editing this code, check whether we solved a similar issue elsewhere in history.",
+      "should_trigger": true,
+      "expected_behavior": "Looks for precedent in past commits and related changes."
+    }
+  ]
+}

--- a/skills/handoffs/SKILL.md
+++ b/skills/handoffs/SKILL.md
@@ -12,6 +12,18 @@ metadata:
 
 # Session Handoff Plan
 
+## What
+
+- Create handoff plans for continuing work across sessions
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 Creates a detailed handoff plan of the conversation for continuing the work in a new session.
 
 The user specified purpose:

--- a/skills/handoffs/evals/evals.json
+++ b/skills/handoffs/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "handoffs",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Create a handoff plan so another session can continue the work safely.",
+      "should_trigger": true,
+      "expected_behavior": "Produces a clear continuation plan with next steps and context."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Write a handoff for the unfinished refactor, including files touched and open questions.",
+      "should_trigger": true,
+      "expected_behavior": "Captures the work state and transfer details."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Implement the feature now.",
+      "should_trigger": false,
+      "expected_behavior": "This is an implementation request, not a handoff."
+    },
+    {
+      "id": "case-4",
+      "prompt": "I need to stop after step two; leave a handoff for the next session.",
+      "should_trigger": true,
+      "expected_behavior": "Documents the current state and the exact next actions."
+    }
+  ]
+}

--- a/skills/implementation-logger/SKILL.md
+++ b/skills/implementation-logger/SKILL.md
@@ -9,6 +9,18 @@ user-invocable: true
 
 # Implementation Logger
 
+## What
+
+- Log implementation decisions — tracks deviations from plan and captures rationale
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 ## When to Use
 
 Use this skill **during implementation** when:

--- a/skills/implementation-logger/evals/evals.json
+++ b/skills/implementation-logger/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "implementation-logger",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Log the decisions we made while implementing the feature and note any deviations from the plan.",
+      "should_trigger": true,
+      "expected_behavior": "Tracks implementation rationale and changes in direction."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Capture the reasons we skipped a planned step during the refactor.",
+      "should_trigger": true,
+      "expected_behavior": "Records intentional deviations and why they happened."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Plan the whole project from scratch.",
+      "should_trigger": false,
+      "expected_behavior": "This is planning, not logging implementation decisions."
+    },
+    {
+      "id": "case-4",
+      "prompt": "We changed the approach halfway through; log the before/after and the reason.",
+      "should_trigger": true,
+      "expected_behavior": "Records the pivot clearly for later review."
+    }
+  ]
+}

--- a/skills/llm-wiki/SKILL.md
+++ b/skills/llm-wiki/SKILL.md
@@ -12,6 +12,18 @@ metadata:
 
 # LLM Wiki
 
+## What
+
+- Build a persistent compounding wiki from raw sources using the LLM Wiki pattern
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 Build and maintain a persistent, compounding knowledge wiki from raw sources.
 
 Based on [Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f): the LLM incrementally integrates each new source into a structured wiki of markdown files — updating entity pages, flagging contradictions, strengthening cross-references. Synthesis is compiled once and kept current, not re-derived on every query.

--- a/skills/llm-wiki/evals/evals.json
+++ b/skills/llm-wiki/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "llm-wiki",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Turn these raw notes into a persistent LLM wiki entry with useful links and structure.",
+      "should_trigger": true,
+      "expected_behavior": "Creates a reusable wiki-style knowledge artifact."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Build a compounding wiki page from the source material and keep it organized for future reuse.",
+      "should_trigger": true,
+      "expected_behavior": "Synthesizes a durable knowledge base entry."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Summarize this one-off article for me.",
+      "should_trigger": false,
+      "expected_behavior": "This is a summary request, not a persistent wiki build."
+    },
+    {
+      "id": "case-4",
+      "prompt": "I have multiple raw sources about the same topic; merge them into one wiki page without losing key references.",
+      "should_trigger": true,
+      "expected_behavior": "Integrates multiple sources into a structured wiki entry."
+    }
+  ]
+}

--- a/skills/pickup/SKILL.md
+++ b/skills/pickup/SKILL.md
@@ -13,6 +13,18 @@ metadata:
 
 # Pickup Handoff
 
+## What
+
+- Resume work from previous handoff sessions stored in .planning/handoffs/
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 Resumes work from previous handoff sessions which are stored in `.planning/handoffs/`.
 
 ## Usage

--- a/skills/pickup/evals/evals.json
+++ b/skills/pickup/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "pickup",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Resume work from the latest handoff file in .planning/handoffs/.",
+      "should_trigger": true,
+      "expected_behavior": "Finds the handoff, summarizes it, and continues from there."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Pick up the previous session and continue from the documented next step.",
+      "should_trigger": true,
+      "expected_behavior": "Restores prior context and proceeds with the handoff flow."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Start a brand new feature with no previous context.",
+      "should_trigger": false,
+      "expected_behavior": "This is a fresh start, not a pickup flow."
+    },
+    {
+      "id": "case-4",
+      "prompt": "I only know there is a handoff file somewhere; find it and continue the work.",
+      "should_trigger": true,
+      "expected_behavior": "Discovers available handoffs and resumes from the selected one."
+    }
+  ]
+}

--- a/skills/plannotator-setup-goal/SKILL.md
+++ b/skills/plannotator-setup-goal/SKILL.md
@@ -12,6 +12,18 @@ metadata:
 
 # Setup Goal
 
+## What
+
+- Turn ideas into executable goal packages with guided interviews and codebase analysis
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 Turn an idea into a goal package at `goals/<slug>/` through structured discovery, user interview, and codebase exploration.
 
 ## Phases

--- a/skills/plannotator-setup-goal/evals/evals.json
+++ b/skills/plannotator-setup-goal/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "plannotator-setup-goal",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Turn this feature idea into an executable goal package with clear tasks and context.",
+      "should_trigger": true,
+      "expected_behavior": "Produces a structured setup goal package."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Interview me about the idea and then organize the implementation steps.",
+      "should_trigger": true,
+      "expected_behavior": "Uses guided clarification to produce a usable plan package."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Just build the feature directly.",
+      "should_trigger": false,
+      "expected_behavior": "This is implementation, not setup or planning."
+    },
+    {
+      "id": "case-4",
+      "prompt": "I have a rough idea and a messy repo; help me turn it into a concrete goal with steps.",
+      "should_trigger": true,
+      "expected_behavior": "Brings structure to an under-defined idea and repo context."
+    }
+  ]
+}

--- a/skills/portless-local/SKILL.md
+++ b/skills/portless-local/SKILL.md
@@ -13,6 +13,18 @@ metadata:
 
 # Portless - Named .localhost URLs
 
+## What
+
+- Replace port numbers with stable named .localhost URLs for local development
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 Replace port numbers with stable, named `.localhost` URLs for local development. For humans and agents.
 
 > **Note:** By default, use HTTP (`http://myapp.localhost`). Only enable HTTPS (`--https` or `PORTLESS_HTTPS=1`) if the user specifically requests it (e.g., for OAuth, secure cookies, or HTTPS-only features).

--- a/skills/portless-local/evals/evals.json
+++ b/skills/portless-local/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "portless-local",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Replace the port numbers in my local dev setup with stable named .localhost URLs.",
+      "should_trigger": true,
+      "expected_behavior": "Maps ports to stable local hostnames and updates the configuration."
+    },
+    {
+      "id": "case-2",
+      "prompt": "I want local services accessible through friendly hostnames instead of raw ports.",
+      "should_trigger": true,
+      "expected_behavior": "Sets up portless local access using named URLs."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Deploy the app to the internet.",
+      "should_trigger": false,
+      "expected_behavior": "This is deployment, not local port mapping."
+    },
+    {
+      "id": "case-4",
+      "prompt": "I have several local services on random ports and keep forgetting them; give them stable names.",
+      "should_trigger": true,
+      "expected_behavior": "Creates a predictable local naming scheme for ports."
+    }
+  ]
+}

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -12,6 +12,18 @@ metadata:
 
 # Fix PR Review Comments
 
+## What
+
+- Fix PR review comments by implementing requested changes
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 Fix PR review comments by implementing the requested changes.
 
 ## Usage

--- a/skills/pr-review/evals/evals.json
+++ b/skills/pr-review/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "pr-review",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Apply the requested PR review changes and make the branch ready for another review pass.",
+      "should_trigger": true,
+      "expected_behavior": "Implements reviewer feedback directly in the branch."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Fix the comments from the PR review one by one and keep the changes minimal.",
+      "should_trigger": true,
+      "expected_behavior": "Addresses review comments with targeted edits."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Review the PR comments and summarize them.",
+      "should_trigger": false,
+      "expected_behavior": "This is a review-summary request, not a fix-up request."
+    },
+    {
+      "id": "case-4",
+      "prompt": "The reviewer flagged a bug in the edge case handling; patch it without widening scope.",
+      "should_trigger": true,
+      "expected_behavior": "Makes the requested fix while avoiding unrelated changes."
+    }
+  ]
+}

--- a/skills/prd/SKILL.md
+++ b/skills/prd/SKILL.md
@@ -12,6 +12,18 @@ metadata:
 
 # PRD Generator
 
+## What
+
+- Generate Product Requirements Documents from feature ideas — plans specs and requirements
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 Create detailed Product Requirements Documents that are clear, actionable, and suitable for implementation.
 
 ---

--- a/skills/prd/evals/evals.json
+++ b/skills/prd/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "prd",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Turn this feature idea into a PRD with goals, requirements, and constraints.",
+      "should_trigger": true,
+      "expected_behavior": "Produces a structured product requirements document."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Draft a PRD for the new workflow and keep it practical and specific.",
+      "should_trigger": true,
+      "expected_behavior": "Creates a clear PRD rather than a vague concept note."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Implement the workflow.",
+      "should_trigger": false,
+      "expected_behavior": "This asks for code, not a PRD."
+    },
+    {
+      "id": "case-4",
+      "prompt": "I only have a rough idea and some constraints; create a PRD that clarifies the scope and success criteria.",
+      "should_trigger": true,
+      "expected_behavior": "Expands a vague idea into explicit product requirements."
+    }
+  ]
+}

--- a/skills/qmd-knowledge/SKILL.md
+++ b/skills/qmd-knowledge/SKILL.md
@@ -12,6 +12,18 @@ metadata:
 
 # QMD Knowledge
 
+## What
+
+- Manage project knowledge with qmd — captures learnings, decisions, and conventions
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 ## What I do
 
 - Record and retrieve project learnings and insights

--- a/skills/qmd-knowledge/evals/evals.json
+++ b/skills/qmd-knowledge/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "qmd-knowledge",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Capture this learning in qmd so the project knowledge stays reusable.",
+      "should_trigger": true,
+      "expected_behavior": "Writes durable project knowledge in qmd form."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Add the decision and convention to the knowledge base with the right qmd structure.",
+      "should_trigger": true,
+      "expected_behavior": "Stores a reusable knowledge artifact with context."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Search the docs for the answer.",
+      "should_trigger": false,
+      "expected_behavior": "This is search, not knowledge capture."
+    },
+    {
+      "id": "case-4",
+      "prompt": "We learned a new constraint during debugging; record it in qmd with links to the related files.",
+      "should_trigger": true,
+      "expected_behavior": "Captures a stable lesson and its context."
+    }
+  ]
+}

--- a/skills/quiz-me/SKILL.md
+++ b/skills/quiz-me/SKILL.md
@@ -9,6 +9,18 @@ user-invocable: true
 
 # Quiz Me
 
+## What
+
+- Verify understanding after implementation with targeted quizzes
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 ## When to Use
 
 Use this skill **after implementation** when:

--- a/skills/quiz-me/evals/evals.json
+++ b/skills/quiz-me/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "quiz-me",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Quiz me on the implementation so I can verify I understand the important parts.",
+      "should_trigger": true,
+      "expected_behavior": "Generates targeted questions to test understanding."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Ask me a short set of questions about the feature I just built.",
+      "should_trigger": true,
+      "expected_behavior": "Creates a focused comprehension quiz."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Explain the feature to me again.",
+      "should_trigger": false,
+      "expected_behavior": "This is explanation, not quiz generation."
+    },
+    {
+      "id": "case-4",
+      "prompt": "Make the quiz harder by including edge cases and trade-offs, not just definitions.",
+      "should_trigger": true,
+      "expected_behavior": "Tests deeper understanding and not just recall."
+    }
+  ]
+}

--- a/skills/ralph/SKILL.md
+++ b/skills/ralph/SKILL.md
@@ -13,6 +13,18 @@ metadata:
 
 # Ralph PRD Converter
 
+## What
+
+- Convert PRDs to prd.json format for the Ralph autonomous agent system
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 Converts existing PRDs to the prd.json format that Ralph uses for autonomous execution.
 
 ---

--- a/skills/ralph/evals/evals.json
+++ b/skills/ralph/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "ralph",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Convert this PRD into prd.json for the Ralph autonomous agent system.",
+      "should_trigger": true,
+      "expected_behavior": "Transforms the PRD into the required structured JSON format."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Take the product spec and emit the Ralph-compatible prd.json file.",
+      "should_trigger": true,
+      "expected_behavior": "Generates the agent-ready JSON representation."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Write a PRD for me.",
+      "should_trigger": false,
+      "expected_behavior": "This is spec writing, not conversion to prd.json."
+    },
+    {
+      "id": "case-4",
+      "prompt": "The PRD is messy and long; normalize it into prd.json while preserving the key requirements.",
+      "should_trigger": true,
+      "expected_behavior": "Extracts structured fields from a noisy PRD."
+    }
+  ]
+}

--- a/skills/slop/SKILL.md
+++ b/skills/slop/SKILL.md
@@ -12,6 +12,18 @@ metadata:
 
 # Remove AI Code Slop
 
+## What
+
+- Remove AI-generated code slop from git diffs to maintain code quality
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 Check the diff against a branch and remove all AI-generated slop introduced in this branch. Simplifies and refines code for clarity, consistency, and maintainability while preserving all functionality.
 
 ## Usage

--- a/skills/slop/evals/evals.json
+++ b/skills/slop/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "slop",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Remove the AI-generated code slop from this diff and keep only the necessary changes.",
+      "should_trigger": true,
+      "expected_behavior": "Cleans up unnecessary clutter and preserves substance."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Tighten this patch so the review focuses on the meaningful changes.",
+      "should_trigger": true,
+      "expected_behavior": "Reduces unnecessary verbosity and mechanical noise."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Refactor this code for performance.",
+      "should_trigger": false,
+      "expected_behavior": "This is a general refactor request, not slop removal."
+    },
+    {
+      "id": "case-4",
+      "prompt": "The branch contains a lot of filler comments and noisy helpers; strip the slop without changing behavior.",
+      "should_trigger": true,
+      "expected_behavior": "Removes superficial clutter while preserving functionality."
+    }
+  ]
+}

--- a/skills/spec-interview/SKILL.md
+++ b/skills/spec-interview/SKILL.md
@@ -9,6 +9,18 @@ user-invocable: true
 
 # Spec Interview
 
+## What
+
+- Clarify requirements through targeted questions — uncovers unknown unknowns in specs
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 ## When to Use
 
 Use this skill when:

--- a/skills/spec-interview/evals/evals.json
+++ b/skills/spec-interview/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "spec-interview",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Ask targeted questions to clarify the requirements before we implement anything.",
+      "should_trigger": true,
+      "expected_behavior": "Produces a focused spec interview that uncovers missing details."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Interview me about the feature so the spec is precise enough to build.",
+      "should_trigger": true,
+      "expected_behavior": "Surfaces assumptions and unclear areas with good questions."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Start coding now.",
+      "should_trigger": false,
+      "expected_behavior": "This is an implementation request, not a clarification interview."
+    },
+    {
+      "id": "case-4",
+      "prompt": "The request is vague and could mean two different workflows; ask the minimum set of questions needed to pin it down.",
+      "should_trigger": true,
+      "expected_behavior": "Uses targeted clarification to remove ambiguity."
+    }
+  ]
+}

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -12,6 +12,18 @@ metadata:
 
 # Test-Driven Development (TDD)
 
+## What
+
+- Guide through the Red-Green-Refactor cycle for test-driven development
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 Guides you through the complete TDD workflow with Red-Green-Refactor cycle.
 
 ## Usage

--- a/skills/tdd/evals/evals.json
+++ b/skills/tdd/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "tdd",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Guide me through a full Red-Green-Refactor cycle for this new behavior.",
+      "should_trigger": true,
+      "expected_behavior": "Runs TDD with failing test, minimal fix, and refactor guidance."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Help me write the first failing test and then get to green step by step.",
+      "should_trigger": true,
+      "expected_behavior": "Supports the classic TDD loop."
+    },
+    {
+      "id": "case-3",
+      "prompt": "Write the feature directly without tests.",
+      "should_trigger": false,
+      "expected_behavior": "This is opposite of TDD."
+    },
+    {
+      "id": "case-4",
+      "prompt": "I already have a failing test; now help me move through green and refactor safely.",
+      "should_trigger": true,
+      "expected_behavior": "Continues an existing TDD cycle and keeps the steps disciplined."
+    }
+  ]
+}

--- a/skills/tmux/SKILL.md
+++ b/skills/tmux/SKILL.md
@@ -12,6 +12,18 @@ metadata:
 
 # 🚀 tmux Skill
 
+## What
+
+- Control tmux sessions remotely — send commands, capture output, manage panes
+
+## Why
+
+- This skill gives you a repeatable way to handle the task instead of improvising each time.
+
+## How
+
+- Follow the sections below for the concrete steps, commands, checks, and guardrails.
+
 Control tmux sessions programmatically to run interactive terminal applications (REPLs, debuggers, databases) without blocking.
 
 ---

--- a/skills/tmux/evals/evals.json
+++ b/skills/tmux/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill": "tmux",
+  "cases": [
+    {
+      "id": "case-1",
+      "prompt": "Control this tmux session remotely and capture the pane output after running the command.",
+      "should_trigger": true,
+      "expected_behavior": "Uses tmux to manage an interactive session and read its output."
+    },
+    {
+      "id": "case-2",
+      "prompt": "Set up a clean tmux socket, send commands to the session, and then collect the pane contents.",
+      "should_trigger": true,
+      "expected_behavior": "Handles session control and output capture programmatically."
+    },
+    {
+      "id": "case-3",
+      "prompt": "List my files.",
+      "should_trigger": false,
+      "expected_behavior": "This is unrelated to tmux control."
+    },
+    {
+      "id": "case-4",
+      "prompt": "I need to drive a REPL and keep it isolated from my personal tmux sessions.",
+      "should_trigger": true,
+      "expected_behavior": "Uses an isolated tmux socket for interactive terminal automation."
+    }
+  ]
+}


### PR DESCRIPTION
## What

- Adds a new `docs/skill-evals.md` guide for defining skill evals before publishing.
- Updates `CONTRIBUTING.md` to require eval prompts and a negative case for each new skill.

## Why

- The repo should not ship skills without a small, explicit eval set.
- This makes it easier to catch near-miss prompts, ambiguous wording, and failure cases before release.

## How

- Documents a minimal eval set, what to record, and a review checklist.
- Replaces the vague skill test step with concrete eval prompts and coverage expectations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “skill evals” guide explaining how to design and run prompt evaluation sets before publishing a new skill, including positive triggers, near-miss negatives, and edge/failure-mode cases.
  * Updated contribution instructions to include creating skill evaluation prompts (with a negative case), then renumbered and clarified the remaining steps for updating skill rules and documenting the new skill.
  * Revised the testing checklist to validate both correct triggering and that near-miss prompts remain inactive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->