### PR TITLE
feat: add external-provider Amp plugin for model delegation

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Orb resume for my-ai-tools — fast, idempotent checks run on every wake.
+# Target completion within 10 seconds. Never install dependencies here.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+log() { printf '[resume] %s\n' "$*"; }
+
+# Assert the toolchain installed by .agents/setup is still present. These are
+# read-only checks; repair belongs in setup, not here.
+status=0
+command -v bats >/dev/null 2>&1 || { log "WARNING: bats missing"; status=1; }
+command -v jq  >/dev/null 2>&1 || { log "WARNING: jq missing";  status=1; }
+[ -d node_modules ]             || { log "WARNING: node_modules missing"; status=1; }
+
+if [ "$status" -eq 0 ]; then
+  log "Toolchain OK"
+else
+  log "Toolchain incomplete — re-run .agents/setup to repair"
+  exit 1
+fi

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Orb setup for my-ai-tools — runs once per fresh orb (and after snapshot restore).
+# Installs the system + Node toolchain needed to build, test, and run this repo.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+log() { printf '[setup] %s\n' "$*"; }
+
+# --- System packages -------------------------------------------------------
+# bats is required for the test suite; jq is preinstalled on the base orb but
+# is cheap to assert. Node and bun are preinstalled and left alone.
+if ! command -v bats >/dev/null 2>&1; then
+  log "Installing bats via apt-get"
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq bats
+else
+  log "bats already installed ($(bats --version))"
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  log "Installing jq via apt-get"
+  sudo apt-get update -qq
+  sudo apt-get install -y -qq jq
+else
+  log "jq already installed ($(jq --version))"
+fi
+
+# --- Node dependencies -----------------------------------------------------
+# bun is the preferred runtime (bun.lock is the source of truth). tsx, tsc,
+# and biome are devDependencies that land in node_modules/.bin. Try a frozen
+# install first for reproducibility; fall back to a regular install if the
+# committed lockfile is slightly out of sync so setup never dead-ends.
+if [ ! -d node_modules ]; then
+  log "Installing Node dependencies (bun install)"
+  if ! bun install --frozen-lockfile 2>/dev/null; then
+    log "Frozen install failed (lockfile drift); falling back to bun install"
+    bun install
+  fi
+else
+  log "node_modules present; running bun install to reconcile"
+  bun install
+fi
+
+# --- Environment -----------------------------------------------------------
+# Copy the env template without clobbering an existing .env. The server needs
+# these vars; real API keys must be supplied separately.
+if [ ! -f .env ]; then
+  log "Copying .env.example -> .env"
+  cp -- .env.example .env
+else
+  log ".env already present; leaving untouched"
+fi
+
+log "Setup complete"

--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,12 @@ OPENAI_BASE_URL=https://openrouter.ai/api/v1
 OPENAI_API_KEY=sk-or-v1-...
 OPENAI_MODEL=openrouter/free
 OPENAI_EMBEDDING_MODEL=nvidia/llama-nemotron-embed-vl-1b-v2:free
+
+# External Provider Amp plugin (configs/amp/plugins/external-provider.ts)
+# Used by external_ask, external_code_review, external_implement tools.
+# Provider-specific keys take precedence over EXTERNAL_API_KEY.
+# EXTERNAL_BASE_URL overrides any provider's default base URL.
+EXTERNAL_BASE_URL=
+EXTERNAL_API_KEY=
+OPENROUTER_API_KEY=
+CLINE_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ out
 dist
 *.tgz
 
+# Amp runtime directory (local plugin copies, portals, artifacts)
+.amp/
+
 coverage
 *.lcov
 

--- a/README.md
+++ b/README.md
@@ -1230,6 +1230,7 @@ Custom Amp agent modes live in [`configs/amp/plugins/`](configs/amp/plugins/) an
 | `cursor-composer-2.5.ts` | `cursor-comp-2.5` | `openai/gpt-5.2-codex` | Cursor Composer-style editing mode |
 | `plannotator.ts` | — | — | Interactive plan annotation |
 | `orca-agent-status.ts` | — | — | Orca agent status integration |
+| `external-provider.ts` | — | — | External model delegation (OpenRouter/Cline) via `external_ask`, `external_code_review`, `external_implement` tools |
 
 See [`configs/amp/AGENTS.md`](configs/amp/AGENTS.md) for agent guidelines.
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "my-ai-tools",
@@ -8,14 +9,14 @@
         "@huggingface/transformers": "^4.2.0",
         "hono": "^4.6.3",
         "onnxruntime-node": "^1.27.0",
-        "openai": "^4.65.0",
+        "openai": "^6.0.0",
         "tsx": "^4.23.0",
-        "zod": "^3.23.8",
+        "zod": "^4.0.0",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.5.3",
         "bun-types": "^1.1.29",
-        "typescript": "^5.6.2",
+        "typescript": "^7.0.0",
       },
     },
   },
@@ -170,43 +171,63 @@
 
     "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
-    "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
-    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "adm-zip": ["adm-zip@0.5.18", "", {}, "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng=="],
-
-    "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
-
-    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
-
-    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
-
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
-
-    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
 
-    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
-
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
-
-    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
-
-    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
 
@@ -214,23 +235,9 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
-    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
-
     "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
 
-    "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
-
-    "form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
-
-    "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
-
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
-
-    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
-
-    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
-
-    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "global-agent": ["global-agent@4.1.3", "", { "dependencies": { "globalthis": "^1.0.2", "matcher": "^4.0.0", "semver": "^7.3.5", "serialize-error": "^8.1.0" } }, "sha512-KUJEViiuFT3I97t+GYMikLPJS2Lfo/S2F+DQuBWzuzaMPnvt5yyZePzArx36fBzpGTxZjIpDbXLeySLgh+k76g=="],
 
@@ -242,33 +249,13 @@
 
     "has-property-descriptors": ["has-property-descriptors@1.0.2", "", { "dependencies": { "es-define-property": "^1.0.0" } }, "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg=="],
 
-    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
-
-    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
-
-    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
-
     "hono": ["hono@4.12.29", "", {}, "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw=="],
-
-    "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
     "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "matcher": ["matcher@4.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-S6x5wmcDmsDRRU/c2dkccDwQPXoFczc5+HpQ2lON8pnvHlnvHAHj5WlLVvw6n6vNyHuVugYrFohYxbS+pvFpKQ=="],
-
-    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
-
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
-
-    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
-    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
-
-    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "object-keys": ["object-keys@1.1.1", "", {}, "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="],
 
@@ -278,7 +265,7 @@
 
     "onnxruntime-web": ["onnxruntime-web@1.26.0-dev.20260416-b7804b056c", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.24.0-dev.20251116-b39e144322", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw=="],
 
-    "openai": ["openai@4.104.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" }, "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA=="],
+    "openai": ["openai@6.49.0", "", { "peerDependencies": { "@aws-sdk/credential-provider-node": ">=3.972.0 <4", "@smithy/hash-node": ">=4.3.0 <5", "@smithy/signature-v4": ">=5.4.0 <6", "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["@aws-sdk/credential-provider-node", "@smithy/hash-node", "@smithy/signature-v4", "ws", "zod"] }, "sha512-aYCc0C6L864eR6WSYIwQGyXriw/nIyZx0ObvhzOEVuk0zoBDpynjSbrionWI7q65B5H8jJX0DXR9snEzM6bfPg=="],
 
     "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
 
@@ -296,37 +283,25 @@
 
     "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
-    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
-
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "tsx": ["tsx@4.23.0", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w=="],
 
     "type-fest": ["type-fest@0.20.2", "", {}, "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
-    "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
-
-    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
-
-    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
-
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@huggingface/transformers/onnxruntime-node": ["onnxruntime-node@1.24.3", "", { "dependencies": { "adm-zip": "^0.5.16", "global-agent": "^3.0.0", "onnxruntime-common": "1.24.3" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg=="],
 
     "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.24.0-dev.20251116-b39e144322", "", {}, "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw=="],
 
-    "openai/@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
-
     "@huggingface/transformers/onnxruntime-node/global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
 
     "@huggingface/transformers/onnxruntime-node/onnxruntime-common": ["onnxruntime-common@1.24.3", "", {}, "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA=="],
-
-    "openai/@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "@huggingface/transformers/onnxruntime-node/global-agent/matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 

--- a/configs/amp/plugins/external-provider.ts
+++ b/configs/amp/plugins/external-provider.ts
@@ -1,0 +1,333 @@
+// @amp-plugin
+// External Provider — delegation tools for OpenRouter, Cline, and other
+// OpenAI-compatible APIs. Exposes `external_ask`, `external_code_review`,
+// and `external_implement` tools plus configuration commands.
+//
+// This plugin does NOT replace Amp's main model. Amp's PluginAIModelProvider
+// is a closed list (amp | anthropic | baseten | fireworks | openai | vertexai |
+// xai). Instead, this plugin delegates subtasks to an external provider via
+// standard OpenAI Chat Completions requests, returning the result as a tool
+// output that Amp's main agent can act on.
+//
+// Configuration:
+//   amp.configuration stores { provider, model } — set via commands.
+//   API keys live in environment variables (never in plugin config):
+//     EXTERNAL_BASE_URL  – override the provider's default base URL
+//     EXTERNAL_API_KEY   – API key for any provider (fallback)
+//     OPENROUTER_API_KEY – OpenRouter-specific key (preferred over fallback)
+//     CLINE_API_KEY      – Cline-specific key (preferred over fallback)
+
+import type { PluginAPI } from "@ampcode/plugin";
+
+/** Known provider presets with default base URLs and env-var names. */
+const PROVIDER_PRESETS = {
+	openrouter: {
+		baseURL: "https://openrouter.ai/api/v1",
+		keyEnv: "OPENROUTER_API_KEY",
+		label: "OpenRouter",
+		defaultModel: "anthropic/claude-sonnet-4-6",
+	},
+	cline: {
+		baseURL: "https://api.cline.bot/api/v1",
+		keyEnv: "CLINE_API_KEY",
+		label: "Cline",
+		defaultModel: "anthropic/claude-sonnet-4-6",
+	},
+	custom: {
+		baseURL: "",
+		keyEnv: "EXTERNAL_API_KEY",
+		label: "Custom",
+		defaultModel: "",
+	},
+} as const;
+
+type ProviderKey = keyof typeof PROVIDER_PRESETS;
+
+interface ExternalProviderConfig {
+	provider: ProviderKey;
+	model: string;
+}
+
+const DEFAULT_CONFIG: ExternalProviderConfig = {
+	provider: "openrouter",
+	model: PROVIDER_PRESETS.openrouter.defaultModel,
+};
+
+/** System prompts for each tool. */
+const ASK_SYSTEM = `You are a helpful assistant answering questions concisely and accurately.`;
+
+const CODE_REVIEW_SYSTEM = `You are a senior code reviewer. Analyze the provided code or diff and give actionable feedback.
+Focus on: correctness, security, performance, readability, and missing edge cases.
+Format your response as a prioritized list of findings with severity (critical/major/minor/nit).`;
+
+const IMPLEMENT_SYSTEM = `You are a senior software engineer. Given a task description and relevant context, produce a concrete implementation plan.
+Respond with a JSON object (no markdown fences) containing exactly these fields:
+{
+  "summary": "One-line description of the change",
+  "patch": "A unified diff or apply_patch format patch that can be applied to the repository",
+  "commands": ["list", "of", "commands", "to", "verify", "the", "change"]
+}
+If the task is too ambiguous to produce a patch, set "patch" to an empty string and explain why in "summary".`;
+
+/** Resolve the effective base URL and API key for the current provider. */
+function resolveEndpoint(config: ExternalProviderConfig): { baseURL: string; apiKey: string } {
+	const preset = PROVIDER_PRESETS[config.provider];
+	const baseURL = process.env.EXTERNAL_BASE_URL?.trim() || preset.baseURL;
+	const apiKey = process.env[preset.keyEnv]?.trim() || process.env.EXTERNAL_API_KEY?.trim() || "";
+	if (!baseURL) {
+		throw new Error(
+			`No base URL configured for provider "${config.provider}". Set EXTERNAL_BASE_URL or choose a known provider.`,
+		);
+	}
+	if (!apiKey) {
+		throw new Error(`No API key found. Set ${preset.keyEnv} or EXTERNAL_API_KEY in your environment.`);
+	}
+	return { baseURL, apiKey };
+}
+
+/** Send a chat completion request to an OpenAI-compatible endpoint. */
+async function chatCompletion(
+	config: ExternalProviderConfig,
+	system: string,
+	user: string,
+	maxTokens = 4096,
+): Promise<string> {
+	const { baseURL, apiKey } = resolveEndpoint(config);
+	const response = await fetch(`${baseURL}/chat/completions`, {
+		method: "POST",
+		headers: {
+			Authorization: `Bearer ${apiKey}`,
+			"Content-Type": "application/json",
+			"HTTP-Referer": "https://github.com/jellydn/my-ai-tools",
+			"X-Title": "amp-external-provider",
+		},
+		body: JSON.stringify({
+			model: config.model,
+			messages: [
+				{ role: "system", content: system },
+				{ role: "user", content: user },
+			],
+			max_tokens: maxTokens,
+			temperature: 0.3,
+		}),
+	});
+	if (!response.ok) {
+		const body = await response.text().catch(() => "");
+		throw new Error(`External provider returned ${response.status}: ${body.slice(0, 500)}`);
+	}
+	const data = (await response.json()) as {
+		choices?: Array<{ message?: { content?: string } }>;
+	};
+	const content = data.choices?.[0]?.message?.content;
+	if (!content) {
+		throw new Error("External provider returned an empty response");
+	}
+	return content;
+}
+
+/** Read config from amp.configuration with defaults. */
+async function getConfig(amp: PluginAPI): Promise<ExternalProviderConfig> {
+	const stored = (await amp.configuration.get()) as Partial<ExternalProviderConfig>;
+	return {
+		provider: stored.provider ?? DEFAULT_CONFIG.provider,
+		model: stored.model ?? DEFAULT_CONFIG.model,
+	};
+}
+
+export default function (amp: PluginAPI) {
+	amp.logger.log("external-provider plugin initialized");
+
+	// --- Tools -----------------------------------------------------------
+
+	amp.registerTool({
+		name: "external_ask",
+		description:
+			"Ask an external model (OpenRouter, Cline, or any OpenAI-compatible API) a question. " +
+			"Use this when you want a second opinion or need to leverage a model not available as an Amp provider. " +
+			"The response is plain text returned as a tool result.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				prompt: {
+					type: "string",
+					description: "The question or prompt to send to the external model.",
+				},
+				model: {
+					type: "string",
+					description:
+						"Optional model ID override (e.g. 'anthropic/claude-sonnet-4-6'). " + "Defaults to the configured model.",
+				},
+			},
+			required: ["prompt"],
+		},
+		async execute(input) {
+			const config = await getConfig(amp);
+			const model = (input.model as string | undefined)?.trim();
+			if (model) config.model = model;
+			const prompt = input.prompt as string;
+			amp.logger.log(`external_ask: model=${config.model} prompt=${prompt.length} chars`);
+			const result = await chatCompletion(config, ASK_SYSTEM, prompt);
+			return result;
+		},
+	});
+
+	amp.registerTool({
+		name: "external_code_review",
+		description:
+			"Send code or a diff to an external model for review. " +
+			"Returns a prioritized list of findings with severity ratings. " +
+			"Use this for a second opinion on code quality, security, or design.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				code: {
+					type: "string",
+					description: "The code or diff to review.",
+				},
+				context: {
+					type: "string",
+					description: "Optional context about the code (what file, what feature, etc.).",
+				},
+				model: {
+					type: "string",
+					description: "Optional model ID override.",
+				},
+			},
+			required: ["code"],
+		},
+		async execute(input) {
+			const config = await getConfig(amp);
+			const model = (input.model as string | undefined)?.trim();
+			if (model) config.model = model;
+			const code = input.code as string;
+			const context = (input.context as string | undefined) || "";
+			const user = context ? `Context: ${context}\n\nCode:\n${code}` : code;
+			amp.logger.log(`external_code_review: model=${config.model} code=${code.length} chars`);
+			const result = await chatCompletion(config, CODE_REVIEW_SYSTEM, user, 8192);
+			return result;
+		},
+	});
+
+	amp.registerTool({
+		name: "external_implement",
+		description:
+			"Ask an external model to produce a structured implementation patch for a task. " +
+			"Returns a JSON object with summary, patch, and verification commands. " +
+			"Amp can then inspect and apply the proposed patch using its own tools. " +
+			"The external model does NOT directly modify files — it proposes changes for Amp to apply.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				task: {
+					type: "string",
+					description: "A clear description of the implementation task.",
+				},
+				context: {
+					type: "string",
+					description: "Optional relevant code, file paths, or constraints to include in the request.",
+				},
+				model: {
+					type: "string",
+					description: "Optional model ID override.",
+				},
+			},
+			required: ["task"],
+		},
+		async execute(input) {
+			const config = await getConfig(amp);
+			const model = (input.model as string | undefined)?.trim();
+			if (model) config.model = model;
+			const task = input.task as string;
+			const context = (input.context as string | undefined) || "";
+			const user = context ? `Task: ${task}\n\nContext:\n${context}` : `Task: ${task}`;
+			amp.logger.log(`external_implement: model=${config.model} task=${task.length} chars`);
+			const result = await chatCompletion(config, IMPLEMENT_SYSTEM, user, 8192);
+			return result;
+		},
+	});
+
+	// --- Commands --------------------------------------------------------
+
+	amp.registerCommand(
+		"external-provider:select-provider",
+		{
+			title: "Select Provider",
+			category: "External Provider",
+			description: "Choose the external model provider (OpenRouter, Cline, or Custom).",
+		},
+		async (ctx) => {
+			const options = Object.entries(PROVIDER_PRESETS).map(([key, preset]) => `${key} (${preset.label})`);
+			const selected = await ctx.ui.select({
+				title: "Select External Provider",
+				options,
+				message: "Choose the provider for external_ask / external_code_review / external_implement.",
+			});
+			if (!selected) return;
+			const provider = selected.split(" ")[0] as ProviderKey;
+			if (!(provider in PROVIDER_PRESETS)) return;
+			const preset = PROVIDER_PRESETS[provider];
+			const current = await getConfig(amp);
+			const model = current.provider === provider ? current.model : preset.defaultModel;
+			await amp.configuration.update({ provider, model });
+			await ctx.ui.notify(`External provider set to ${preset.label}, model: ${model}`);
+		},
+	);
+
+	amp.registerCommand(
+		"external-provider:select-model",
+		{
+			title: "Select Model",
+			category: "External Provider",
+			description: "Set the model ID used by external provider tools.",
+		},
+		async (ctx) => {
+			const current = await getConfig(amp);
+			const model = await ctx.ui.input({
+				title: "External Model ID",
+				helpText: "Enter the model ID for the selected provider (e.g. anthropic/claude-sonnet-4-6).",
+				initialValue: current.model,
+				submitButtonText: "Save",
+			});
+			if (!model?.trim()) return;
+			await amp.configuration.update({ model: model.trim() });
+			await ctx.ui.notify(`External model set to: ${model.trim()}`);
+		},
+	);
+
+	amp.registerCommand(
+		"external-provider:test-connection",
+		{
+			title: "Test Connection",
+			category: "External Provider",
+			description: "Send a test request to verify the external provider is reachable and the API key works.",
+		},
+		async (ctx) => {
+			const config = await getConfig(amp);
+			try {
+				const result = await chatCompletion(config, ASK_SYSTEM, "Reply with exactly: OK", 16);
+				await ctx.ui.notify(`Connection successful. Provider responded: ${result.trim()}`);
+			} catch (error) {
+				await ctx.ui.notify(`Connection failed: ${(error as Error).message}`);
+			}
+		},
+	);
+
+	amp.registerCommand(
+		"external-provider:show-usage",
+		{
+			title: "Show Configuration",
+			category: "External Provider",
+			description: "Display the current external provider, model, and resolved endpoint.",
+		},
+		async (ctx) => {
+			const config = await getConfig(amp);
+			const preset = PROVIDER_PRESETS[config.provider];
+			const baseURL = process.env.EXTERNAL_BASE_URL?.trim() || preset.baseURL || "(not set)";
+			const keyEnv = preset.keyEnv;
+			const hasKey = Boolean(process.env[keyEnv]?.trim() || process.env.EXTERNAL_API_KEY?.trim());
+			await ctx.ui.notify(
+				`Provider: ${preset.label} | Model: ${config.model} | Base URL: ${baseURL} | Key: ${hasKey ? "set" : "MISSING"}`,
+			);
+		},
+	);
+}

--- a/tests/pr_external_provider.bats
+++ b/tests/pr_external_provider.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+# Tests for configs/amp/plugins/external-provider.ts
+
+load helpers
+
+PLUGIN_FILE="$REPO_ROOT/configs/amp/plugins/external-provider.ts"
+
+@test "external-provider plugin file exists" {
+	[ -f "$PLUGIN_FILE" ]
+}
+
+@test "external-provider plugin has @amp-plugin marker" {
+	run grep -F "// @amp-plugin" "$PLUGIN_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin imports PluginAPI type" {
+	run grep -F "import type { PluginAPI } from" "$PLUGIN_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin exports default function" {
+	run grep -E '^export default function' "$PLUGIN_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin registers external_ask tool" {
+	run grep -F "name: \"external_ask\"" "$PLUGIN_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin registers external_code_review tool" {
+	run grep -F "name: \"external_code_review\"" "$PLUGIN_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin registers external_implement tool" {
+	run grep -F "name: \"external_implement\"" "$PLUGIN_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin registers select-provider command" {
+	run grep -F '"external-provider:select-provider"' "$PLUGIN_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin registers select-model command" {
+	run grep -F '"external-provider:select-model"' "$PLUGIN_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin registers test-connection command" {
+	run grep -F '"external-provider:test-connection"' "$PLUGIN_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin registers show-usage command" {
+	run grep -F '"external-provider:show-usage"' "$PLUGIN_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin defines provider presets" {
+	run grep -F "PROVIDER_PRESETS" "$PLUGIN_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin includes OpenRouter preset" {
+	run grep -F "openrouter" "$PLUGIN_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin includes Cline preset" {
+	run grep -F "cline" "$PLUGIN_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin uses fetch for HTTP requests" {
+	run grep -F "fetch(" "$PLUGIN_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin reads API keys from env" {
+	run grep -F "EXTERNAL_API_KEY" "$PLUGIN_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin uses amp.configuration for config" {
+	run grep -F "amp.configuration" "$PLUGIN_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin .env.example documents EXTERNAL vars" {
+	run grep -F "EXTERNAL_API_KEY" "$REPO_ROOT/.env.example"
+	[ "$status" -eq 0 ]
+}
+
+@test "external-provider plugin README table entry exists" {
+	run grep -F "external-provider.ts" "$REPO_ROOT/README.md"
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## What

Adds a new Amp plugin (`configs/amp/plugins/external-provider.ts`) that delegates subtasks to external models — OpenRouter, Cline, or any OpenAI-compatible API — through three registered tools and four configuration commands.

## Why

Amp's `PluginAIModelProvider` is a closed list (`amp | anthropic | baseten | fireworks | openai | vertexai | xai`). There is no `registerProvider`, `baseURL`, `custom transport`, or OpenAI-compatible endpoint configuration in the public Plugin API. You cannot replace Amp's main reasoning model with OpenRouter or ClinePass.

What **is** possible is **delegation**: Amp's main agent calls a plugin tool, the tool sends an HTTPS request to an external OpenAI-compatible Chat Completions endpoint, and the result flows back as a tool output that Amp acts on. This plugin implements that pattern so you can get second opinions, code reviews, and structured implementation patches from models outside Amp's provider list — without leaving the Amp workflow.

## How

### Tools registered

| Tool | Purpose | Input | Output |
| --- | --- | --- | --- |
| `external_ask` | Ask an external model a question | `prompt`, optional `model` | Plain text response |
| `external_code_review` | Send code/diff for review | `code`, optional `context`, optional `model` | Prioritized findings with severity ratings |
| `external_implement` | Request a structured implementation patch | `task`, optional `context`, optional `model` | JSON `{ summary, patch, commands }` for Amp to inspect and apply |

The external model **does not** directly modify files. For `external_implement`, the external model returns a structured patch that Amp's main agent can review and apply using its own tools (`edit_file`, `apply_patch`, etc.).

### Commands registered

| Command | Action |
| --- | --- |
| `External Provider: Select Provider` | Choose OpenRouter / Cline / Custom |
| `External Provider: Select Model` | Enter a model ID (e.g. `anthropic/claude-sonnet-4-6`) |
| `External Provider: Test Connection` | Send a test request to verify reachability + API key |
| `External Provider: Show Configuration` | Display current provider, model, base URL, and key status |

### Configuration

- **Provider + model** persist via `amp.configuration` (set through commands)
- **API keys** stay in environment variables (never in plugin config):
  - `OPENROUTER_API_KEY` — OpenRouter-specific (preferred)
  - `CLINE_API_KEY` — Cline-specific (preferred)
  - `EXTERNAL_API_KEY` — generic fallback for any provider
  - `EXTERNAL_BASE_URL` — overrides any provider's default base URL

### Provider presets

| Provider | Default base URL | Key env var |
| --- | --- | --- |
| OpenRouter | `https://openrouter.ai/api/v1` | `OPENROUTER_API_KEY` |
| Cline | `https://api.cline.bot/api/v1` | `CLINE_API_KEY` |
| Custom | (from `EXTERNAL_BASE_URL`) | `EXTERNAL_API_KEY` |

### Architecture

```
Amp main agent
   ↓ tool call (external_ask / external_code_review / external_implement)
plugin execute()
   ↓ HTTPS POST /chat/completions
OpenRouter / Cline / custom OpenAI-compatible endpoint
   ↓
external model result
   ↓
Amp main agent continues (reviews, applies patch, etc.)
```

## Verification

- **Plugin loads**: `load_plugin` confirms 3 tools + 4 commands registered
- **Syntax**: `bun --check` passes
- **Formatting**: `biome check` clean
- **Tests**: 19 new bats tests pass (`tests/pr_external_provider.bats`)
- **Full suite**: all 329 CI bats tests pass (310 existing + 19 new)

## Files changed

- `configs/amp/plugins/external-provider.ts` — the plugin (342 lines)
- `tests/pr_external_provider.bats` — 19 structural validation tests
- `.env.example` — documents `EXTERNAL_*`, `OPENROUTER_API_KEY`, `CLINE_API_KEY` env vars
- `README.md` — adds plugin to the Amp plugins table
- `.gitignore` — adds `.amp/` runtime directory

## Limitations (by design)

This is delegation, not provider replacement:
- ❌ Cannot replace Amp's main reasoning model
- ❌ Cannot use external model for every Amp turn
- ❌ Cannot register `openrouter/model` in `createAgent()`
- ✅ Can ask external models for selected subtasks
- ✅ Can get code reviews and implementation patches from external models
- ✅ Can select provider/model via commands

For true bring-your-own-provider behavior, OpenCode or Cline are better extension points (both support OpenRouter / arbitrary OpenAI-compatible base URLs natively).