### PR TITLE
feat: add first-class jcode CLI support

### DIFF
--- a/.changeset/add-jcode-cli-tool.md
+++ b/.changeset/add-jcode-cli-tool.md
@@ -1,0 +1,5 @@
+---
+"my-ai-tools": patch
+---
+
+Add first-class support for jcode (https://jcode.sh) — install via Homebrew/curl/PowerShell, ship `configs/jcode/` (`AGENTS.md` → `~/AGENTS.md`, `mcp.json`, `config.toml`, curated skills), wire `install_jcode` / `copy_jcode_configs` / `generate_jcode_configs`, and document with tests.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub license](https://img.shields.io/github/license/jellydn/my-ai-tools)](https://github.com/jellydn/my-ai-tools/blob/main/LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/jellydn/my-ai-tools/pulls)
 
-> **Comprehensive configuration management for AI coding tools** - Replicate my complete setup for Claude Code, OpenCode, Amp, Kilo CLI, Codex, Devin CLI, Kimi Code, Gemini CLI, Antigravity CLI, Pi, GitHub Copilot CLI, Cursor Agent CLI, Factory Droid, Cline, Grok CLI, MiMo-Code, Qoder CLI, Kiro CLI, Codiff, ctx, Open Code Review, and CCS with custom configurations, MCP servers, skills, plugins, and commands.
+> **Comprehensive configuration management for AI coding tools** - Replicate my complete setup for Claude Code, OpenCode, Amp, Kilo CLI, Codex, Devin CLI, Kimi Code, Gemini CLI, Antigravity CLI, Pi, GitHub Copilot CLI, Cursor Agent CLI, Factory Droid, Cline, Grok CLI, MiMo-Code, Qoder CLI, jcode, Kiro CLI, Codiff, ctx, Open Code Review, and CCS with custom configurations, MCP servers, skills, plugins, and commands.
 
 📖 **[View Documentation Website](https://ai-tools.itman.fyi)** - Interactive landing page with full documentation and search.
 
@@ -12,7 +12,7 @@
 
 - 🚀 **One-line installer** - Get started in seconds
 - 🔄 **Bidirectional sync** - Install configs or export your current setup
-- 🤖 **Multiple AI tools** - Claude Code, OpenCode, Amp, CCS, Devin, Kimi Code, Gemini, Antigravity, Grok, MiMo-Code, Qoder CLI, Kiro CLI, Codiff, ctx, Open Code Review, and more
+- 🤖 **Multiple AI tools** - Claude Code, OpenCode, Amp, CCS, Devin, Kimi Code, Gemini, Antigravity, Grok, MiMo-Code, Qoder CLI, jcode, Kiro CLI, Codiff, ctx, Open Code Review, and more
 - 🔌 **MCP Server integration** - Context7, Sequential-thinking, qmd, codebase-memory-mcp, agentmemory, sem, ctx
 - 🎯 **Custom agents & skills** - Pre-configured for maximum productivity
 - 🤝 **Agent Teams** - Coordinate specialized agents for complex workflows (code review, testing, docs)
@@ -152,6 +152,7 @@ The most-used skills across Claude Code, OpenCode, and other AI tools:
 | **Grok**        | context7, sequential-thinking, qmd, codebase-memory-mcp, agentmemory, fff, react-grab-mcp, logpilot, sem, ctx              | Default model `grok-4.5` (high reasoning); UI auto + `rosepine-moon`; Kanagawa theme staged                                                                                                           |
 | **MiMo-Code**   | context7, sequential-thinking, qmd, codebase-memory-mcp, agentmemory, fff, react-grab-mcp, logpilot, sem, ctx              | @plannotator/opencode, opencode-chrome-annotation                                                                                                                                                     |
 | **Qoder CLI**   | context7, sequential-thinking, qmd, codebase-memory-mcp, agentmemory, fff, react-grab-mcp, logpilot, sem, ctx              | -                                                                                                                                                                                                     |
+| **jcode**       | context7, sequential-thinking, qmd, codebase-memory-mcp, agentmemory, fff, react-grab-mcp, logpilot, sem, ctx              | Skills via `~/.jcode/skills/`; machine-wide `~/AGENTS.md`                                                                                                                                             |
 | **Kiro CLI**    | context7, sequential-thinking, qmd, codebase-memory-mcp, agentmemory, fff, react-grab-mcp, logpilot, sem, ctx              | Steering files (AGENTS.md), slash commands, MCP servers, ACP                                                                                                                                          |
 | **Codiff**      | — (desktop app — uses configured agent backend via settings)                                                               | —                                                                                                                                                                                                     |
 
@@ -2884,6 +2885,109 @@ See the full [Qoder CLI docs](https://docs.qoder.com/en/cli/quick-start) for det
 
 ---
 
+## ⚡ jcode (Optional)
+
+RAM-efficient coding agent harness with subscription OAuth (Claude/OpenAI/Gemini/Copilot), swarm multi-agent sessions, semantic memory, and MCP. [Homepage](https://jcode.sh) | [Docs](https://jcode.sh/docs) | [GitHub](https://github.com/1jehuang/jcode)
+
+<details>
+<summary><strong>Installation &amp; Configuration</strong></summary>
+
+### Installation
+
+```bash
+# macOS with Homebrew
+brew tap 1jehuang/jcode
+brew install jcode
+
+# macOS / Linux install script
+curl -fsSL https://jcode.sh/install | bash
+```
+
+```powershell
+# Windows PowerShell
+irm https://jcode.sh/install.ps1 | iex
+```
+
+Or run this repo's installer:
+
+```bash
+./cli.sh
+```
+
+### Configuration
+
+jcode configs are stored in [`configs/jcode/`](configs/jcode/) and installed as:
+
+- [`AGENTS.md`](configs/jcode/AGENTS.md) — machine-wide agent guidelines (installed to `~/AGENTS.md`; project instructions stay in `<repo>/AGENTS.md`)
+- [`mcp.json`](configs/jcode/mcp.json) — global MCP servers (`~/.jcode/mcp.json`)
+- [`config.toml`](configs/jcode/config.toml) — safe display/feature defaults (`~/.jcode/config.toml`; existing local file is preserved)
+- [`skills/`](configs/jcode/skills/) — curated skills installed under `~/.jcode/skills/`
+
+### 🔌 MCP Servers
+
+```json
+{
+    "mcpServers": {
+        "context7": {
+            "command": "npx",
+            "args": ["-y", "@upstash/context7-mcp@latest"]
+        },
+        "sequential-thinking": {
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+        },
+        "qmd": { "command": "qmd", "args": ["mcp"] },
+        "fff": { "command": "fff-mcp", "args": [] },
+        "react-grab-mcp": {
+            "command": "npx",
+            "args": ["-y", "@react-grab/mcp", "--stdio"]
+        },
+        "logpilot": { "command": "logpilot", "args": ["mcp-server"] },
+        "agentmemory": { "command": "npx", "args": ["-y", "@agentmemory/mcp"] },
+        "sem": { "command": "sem-mcp", "args": [] },
+        "ctx": { "command": "ctx", "args": ["mcp", "serve"] },
+        "codebase-memory-mcp": { "command": "codebase-memory-mcp", "args": [] }
+    }
+}
+```
+
+> jcode accepts both `mcpServers` and the historical `servers` key. Only stdio MCP servers are supported today.
+
+**Config Locations:**
+
+| Scope | Path |
+| --- | --- |
+| User config | `~/.jcode/config.toml` |
+| User MCP | `~/.jcode/mcp.json` |
+| Project MCP | `<project>/.jcode/mcp.json` |
+| User AGENTS.md | `~/AGENTS.md` |
+| Project AGENTS.md | `<project>/AGENTS.md` |
+| Skills | `~/.jcode/skills/` |
+| Provider env files | `~/.config/jcode/*.env` |
+
+### Usage
+
+```bash
+# Start jcode TUI
+jcode
+
+# Non-interactive single prompt
+jcode run "say hello"
+
+# Verify configured providers
+jcode auth-test --all-configured
+
+# Browser automation status / setup
+jcode browser status
+jcode browser setup
+```
+
+See the full [jcode docs](https://jcode.sh/docs) for provider login and swarm features.
+
+</details>
+
+---
+
 ## 🥷 Kiro CLI (Optional)
 
 Kiro Dev's AI coding assistant with native MCP support, steering files (AGENTS.md), and ACP (Agent Client Protocol) integration. Ships with `/model`, `/editor`, `/usage`, and custom agents. [Homepage](https://kiro.dev/) | [Docs](https://kiro.dev/docs/cli/installation/) | [GitHub](https://github.com/kirodotdev/Kiro)
@@ -3070,7 +3174,7 @@ ctx mcp serve
 
 The ctx MCP server is configured for all supported AI tools via this repo's config files and the central MCP registry (`configs/mcp-registry.json`):
 
-- **Claude Code**, **Cursor**, **Cline**, **Factory Droid**, **Kimi Code**, **CommandCode**, **Kiro**, **Copilot**, **Qoder CLI**, **Pi**, **Antigravity** — registered in tool-specific `mcpServers` JSON config
+- **Claude Code**, **Cursor**, **Cline**, **Factory Droid**, **Kimi Code**, **CommandCode**, **Kiro**, **Copilot**, **Qoder CLI**, **jcode**, **Pi**, **Antigravity** — registered in tool-specific `mcpServers` JSON config
 - **OpenCode**, **Kilo** — registered in `mcp.ctx` (array-command format)
 - **Codex**, **Grok** — registered in TOML `[mcp_servers.ctx]` format
 - **Claude Code**, **OpenCode**, **Codex**, **Amp**, **Gemini**, **Antigravity**, **CommandCode**, **Copilot**, **Cursor**, **Factory**, **Cline**, **Grok**, **MiMo-Code**, **Qoder CLI**, **Kiro** — also covered by the central `mcp-registry.json` for automatic setup.

--- a/cli.sh
+++ b/cli.sh
@@ -50,6 +50,7 @@ INSTALL_SEQUENCE=(
 	"herdr:install_herdr"
 	"ctx:install_ctx"
 	"qodercli:install_qodercli"
+	"jcode:install_jcode"
 	"kiro:install_kiro"
 	"codiff:install_codiff"
 	"devin:install_devin"
@@ -335,6 +336,8 @@ backup_configs() {
 		copy_config_dir "$HOME/.grok" "$BACKUP_DIR" "grok"
 		copy_config_dir "$HOME/.config/mimocode" "$BACKUP_DIR" "mimocode"
 		copy_config_dir "$HOME/.qoder" "$BACKUP_DIR" "qodercli"
+		copy_config_dir "$HOME/.jcode" "$BACKUP_DIR" "jcode"
+		copy_config_file "$HOME/AGENTS.md" "$BACKUP_DIR/jcode" || true
 		copy_config_dir "$HOME/.kiro" "$BACKUP_DIR" "kiro"
 		copy_config_dir "$HOME/.codiff" "$BACKUP_DIR" "codiff"
 		copy_config_dir "$HOME/.config/devin" "$BACKUP_DIR" "devin"
@@ -561,6 +564,11 @@ copy_configurations() {
 	else
 		log_info "Skipping qodercli config install (not in -y allowlist)"
 	fi
+	if tool_allowed "jcode"; then
+		copy_jcode_configs
+	else
+		log_info "Skipping jcode config install (not in -y allowlist)"
+	fi
 	if tool_allowed "kiro"; then
 		copy_kiro_configs
 	else
@@ -616,6 +624,7 @@ _validate_config_tool_name() {
 		*antigravity-cli/settings.json*) echo "antigravity" ;;
 		*kilo/config.json*) echo "kilo" ;;
 		*kimi-code/mcp.json*) echo "kimi_code" ;;
+		*jcode/mcp.json*) echo "jcode" ;;
 		*pi/settings.json*) echo "pi" ;;
 		*commandcode/*.json*) echo "commandcode" ;;
 		*cline/*.json*) echo "cline" ;;
@@ -659,6 +668,7 @@ validate_all_configs() {
 		"$SCRIPT_DIR/configs/antigravity-cli/settings.json" \
 		"$SCRIPT_DIR/configs/kilo/config.json" \
 		"$SCRIPT_DIR/configs/kimi-code/mcp.json" \
+		"$SCRIPT_DIR/configs/jcode/mcp.json" \
 		"$SCRIPT_DIR/configs/pi/settings.json" \
 		"$SCRIPT_DIR/configs/commandcode/settings.json" \
 		"$SCRIPT_DIR/configs/commandcode/mcp.json" \
@@ -1594,6 +1604,36 @@ copy_qodercli_configs() {
 	log_success "Qoder CLI configs copied"
 }
 
+copy_jcode_configs() {
+	local jcode_status
+	jcode_status=$(detect_tool --detailed "jcode" "$HOME/.jcode") || jcode_status="missing"
+	if [ "$jcode_status" = "missing" ]; then
+		log_info "jcode not detected - skipping jcode config installation"
+		return 0
+	fi
+
+	log_info "Detected jcode (via $jcode_status)"
+	execute_quoted mkdir -p "$HOME/.jcode"
+
+	# jcode loads machine-wide instructions from ~/AGENTS.md (not ~/.jcode/).
+	copy_config_file "$SCRIPT_DIR/configs/jcode/AGENTS.md" "$HOME/" || true
+	copy_config_file "$SCRIPT_DIR/configs/jcode/mcp.json" "$HOME/.jcode/" || true
+
+	# Preserve an existing config.toml so local provider profiles are not clobbered.
+	if [ ! -f "$HOME/.jcode/config.toml" ]; then
+		copy_config_file "$SCRIPT_DIR/configs/jcode/config.toml" "$HOME/.jcode/" || true
+	else
+		log_info "jcode config.toml already exists at ~/.jcode/, preserving existing config"
+	fi
+
+	if [ -d "$SCRIPT_DIR/configs/jcode/skills" ]; then
+		execute_quoted mkdir -p "$HOME/.jcode/skills"
+		safe_copy_dir "$SCRIPT_DIR/configs/jcode/skills" "$HOME/.jcode/skills"
+	fi
+
+	log_success "jcode configs copied"
+}
+
 copy_kiro_configs() {
 	local kiro_status
 	kiro_status=$(detect_tool --detailed "kiro" "$HOME/.kiro") || kiro_status="missing"
@@ -2435,7 +2475,7 @@ main() {
 	echo "║  Claude • OpenCode • Amp • CCS • Codex • Kimi Code • Gemini          ║"
 	echo "║  Antigravity • Pi • Kilo • Copilot • Cursor • Command Code           ║"
 	echo "║  Factory Droid • Cline • Grok • MiMo-Code • herdr                    ║"
-	echo "║  Qoder CLI • Kiro • Codiff • Devin                                   ║"
+	echo "║  Qoder CLI • jcode • Kiro • Codiff • Devin                           ║"
 	echo "║  ctx                                                                 ║"
 	echo "╚══════════════════════════════════════════════════════════════════════╝"
 	echo

--- a/configs/jcode/AGENTS.md
+++ b/configs/jcode/AGENTS.md
@@ -1,0 +1,46 @@
+# 🤖 jcode Agent Guidelines
+
+## Session Management with tmux
+
+Run dev servers, tests, and interactive CLIs inside tmux with the **current directory name as the session name** for easy debugging:
+
+```bash
+SESSION=$(basename "$PWD")
+tmux new -d -s "$SESSION" 2>/dev/null || true
+
+# Run dev server with portless if available, otherwise fallback to npm
+if command -v portless &>/dev/null; then
+    tmux send-keys -t "$SESSION" 'portless run npm run dev' Enter
+else
+    tmux send-keys -t "$SESSION" 'npm run dev' Enter
+fi
+
+tmux capture-pane -p -t "$SESSION" -S -20  # check output
+```
+
+## 🔧 AI Tool Guidelines
+
+- Use the fff MCP tools for all file search operations instead of default tools.
+- Use the sem MCP tools for semantic version control and git operations.
+- When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
+
+## Token Efficiency
+
+- Keep responses concise and actionable; lead with conclusions, file paths, and verification.
+- Scope searches and file reads to the task. Limit command output with filters and line ranges.
+- Use `~/.local/bin/rtk` for supported shell commands when available; bypass it with `RTK_DISABLED=1` when raw output is required.
+- Prefer `codebase-memory-mcp` graph tools for structural code discovery when available.
+- Load supplemental guidance only when the task requires it. Start a fresh session when switching to unrelated work.
+
+## 📋 General Practices
+
+- Read `~/.ai-tools/best-practices.md` only when the repository lacks equivalent guidance or the task needs its detailed workflow.
+- Read `~/.ai-tools/MEMORY.md` and `~/.ai-tools/agent-memory.md` only when deciding whether or where to persist a learning.
+- Read `~/.ai-tools/git-guidelines.md` before destructive or history-changing git operations.
+- Ask before destructive operations — don't guess safety
+- Code is communication — prefer clarity and simplicity
+- Self-documenting code through meaningful names and structure
+- Modular design that can evolve
+- Comments explain why, not what
+- Run typecheck, lint and biome on js/ts file changes after finish.
+- Prefer to use Bun to run scripts if possible, otherwise use tsx to run ts files.

--- a/configs/jcode/config.toml
+++ b/configs/jcode/config.toml
@@ -1,0 +1,11 @@
+# jcode user config — safe defaults only (no secrets).
+# Provider credentials live in ~/.jcode auth files or ~/.config/jcode/*.env.
+# Docs: https://jcode.sh/docs
+
+[display]
+# Set emoji = false (or JCODE_NO_EMOJI=1) for ASCII-only TUI/CLI markers.
+emoji = true
+
+[features]
+memory = true
+swarm = true

--- a/configs/jcode/mcp.json
+++ b/configs/jcode/mcp.json
@@ -1,0 +1,44 @@
+{
+	"mcpServers": {
+		"context7": {
+			"command": "npx",
+			"args": ["-y", "@upstash/context7-mcp@latest"]
+		},
+		"sequential-thinking": {
+			"command": "npx",
+			"args": ["-y", "@modelcontextprotocol/server-sequential-thinking"]
+		},
+		"qmd": {
+			"command": "qmd",
+			"args": ["mcp"]
+		},
+		"fff": {
+			"command": "fff-mcp",
+			"args": []
+		},
+		"react-grab-mcp": {
+			"command": "npx",
+			"args": ["-y", "@react-grab/mcp", "--stdio"]
+		},
+		"logpilot": {
+			"command": "logpilot",
+			"args": ["mcp-server"]
+		},
+		"agentmemory": {
+			"command": "npx",
+			"args": ["-y", "@agentmemory/mcp"]
+		},
+		"sem": {
+			"command": "sem-mcp",
+			"args": []
+		},
+		"ctx": {
+			"command": "ctx",
+			"args": ["mcp", "serve"]
+		},
+		"codebase-memory-mcp": {
+			"command": "codebase-memory-mcp",
+			"args": []
+		}
+	}
+}

--- a/configs/jcode/skills/ai-slop-remover/SKILL.md
+++ b/configs/jcode/skills/ai-slop-remover/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: ai-slop-remover
+description: Remove AI-generated code patterns that don't match codebase style
+license: MIT
+compatibility: kimi-code
+user-invocable: true
+tools: ["fs_read", "grep", "find", "fs_write", "shell"]
+---
+
+You are a code quality engineer. Clean up AI-generated code to match human-written conventions.
+
+## What to Remove
+
+Unnecessary comments, excessive defensive checks, type escape hatches (`any`, `@ts-ignore`), over-engineering, inconsistent style, verbose error handling.
+
+## Output
+
+1-3 sentence summary of changes.

--- a/configs/jcode/skills/code-reviewer/SKILL.md
+++ b/configs/jcode/skills/code-reviewer/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: code-reviewer
+description: Review code for quality, security, and best practices — read-only analysis
+license: MIT
+compatibility: kimi-code
+user-invocable: true
+tools: ["fs_read", "grep", "find"]
+---
+
+You are an expert code reviewer. Provide thorough, constructive code reviews.
+
+## Review Criteria
+
+**Critical (Must Fix)**: Security vulnerabilities, data loss, breaking changes, logic errors.
+**Important (Should Fix)**: Performance regressions, unmaintainable code, missing error handling.
+**Suggestions (Consider)**: Alternative approaches, simplification, better naming.
+
+## Output Format
+
+### Summary | ### Critical Issues | ### Important Improvements | ### Suggestions | ### Positive Notes

--- a/configs/jcode/skills/documentation-writer/SKILL.md
+++ b/configs/jcode/skills/documentation-writer/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: documentation-writer
+description: Create clear documentation for code and APIs
+license: MIT
+compatibility: kimi-code
+user-invocable: true
+tools: ["fs_read", "grep", "find", "fs_write"]
+---
+
+You are an expert technical writer. Create clear, useful documentation.

--- a/configs/jcode/skills/security-audit/SKILL.md
+++ b/configs/jcode/skills/security-audit/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: security-audit
+description: Audit code for security vulnerabilities — read-only analysis
+license: MIT
+compatibility: kimi-code
+user-invocable: true
+tools: ["fs_read", "grep", "find"]
+---
+
+You are a security engineer. Identify vulnerabilities and recommend fixes.
+
+## Checklist
+
+Input validation, auth/authz, data protection, SQLi/XSS/CSRF, dependencies, hardcoded secrets.
+
+## Severity
+
+🔴 Critical | 🟠 High | 🟡 Medium | 🟢 Low | ℹ️ Info

--- a/configs/jcode/skills/test-generator/SKILL.md
+++ b/configs/jcode/skills/test-generator/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: test-generator
+description: Generate comprehensive tests for code changes
+license: MIT
+compatibility: kimi-code
+user-invocable: true
+tools: ["fs_read", "grep", "find", "fs_write", "shell"]
+---
+
+You are an expert test engineer. Write high-quality, maintainable tests.
+
+## Testing Philosophy
+
+Test behavior, not implementation. Cover happy paths, edge cases, error conditions, and integration points. Use descriptive test names with Arrange-Act-Assert pattern. Match the project's existing test framework.

--- a/generate.sh
+++ b/generate.sh
@@ -734,6 +734,31 @@ generate_qodercli_configs() {
 	log_success "Qoder CLI configs generated"
 }
 
+generate_jcode_configs() {
+	log_info "Generating jcode configs..."
+
+	if [ ! -d "$HOME/.jcode" ] && [ ! -f "$HOME/AGENTS.md" ]; then
+		log_warning "jcode config not found under ~/.jcode or ~/AGENTS.md"
+		return 0
+	fi
+
+	execute "mkdir -p \"$SCRIPT_DIR/configs/jcode\""
+
+	# Machine-wide instructions live at ~/AGENTS.md per jcode docs.
+	copy_single "$HOME/AGENTS.md" "$SCRIPT_DIR/configs/jcode/AGENTS.md"
+	copy_single "$HOME/.jcode/mcp.json" "$SCRIPT_DIR/configs/jcode/mcp.json"
+	copy_single "$HOME/.jcode/config.toml" "$SCRIPT_DIR/configs/jcode/config.toml"
+
+	if [ -d "$HOME/.jcode/skills" ]; then
+		copy_skills_with_filter "$HOME/.jcode/skills" "$SCRIPT_DIR/configs/jcode/skills" "jcode"
+		log_success "jcode skills generated"
+	else
+		log_warning "jcode skills directory not found: $HOME/.jcode/skills"
+	fi
+
+	log_success "jcode configs generated"
+}
+
 generate_kiro_configs() {
 	log_info "Generating Kiro CLI configs..."
 
@@ -960,6 +985,9 @@ main() {
 	echo
 
 	generate_qodercli_configs
+	echo
+
+	generate_jcode_configs
 	echo
 
 	generate_kiro_configs

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -720,3 +720,36 @@ install_devin() {
 	}
 	run_installer "Devin CLI" "_run_devin_install" "command -v devin" "devin --version 2>/dev/null || true"
 }
+
+# ─── jcode installation ────────────────────────────────────────────
+
+install_jcode() {
+	_run_jcode_install() {
+		if command -v jcode &>/dev/null; then
+			log_warning "jcode is already installed"
+			return 0
+		fi
+
+		if [ "$IS_WINDOWS" = true ]; then
+			if command -v powershell.exe &>/dev/null; then
+				execute "powershell.exe -NoProfile -ExecutionPolicy Bypass -Command \"irm https://jcode.sh/install.ps1 | iex\""
+			else
+				log_error "PowerShell is required to install jcode on Windows."
+				log_info "Install manually: https://jcode.sh/docs"
+				return 1
+			fi
+		elif command -v brew &>/dev/null; then
+			# Prefer Homebrew on macOS/Linux when available.
+			if ! brew tap 1jehuang/jcode &>/dev/null; then
+				log_error "Failed to tap 1jehuang/jcode"
+				return 1
+			fi
+			execute "brew install jcode"
+		else
+			execute_installer "https://jcode.sh/install" "" "jcode"
+		fi
+
+		log_success "jcode installed"
+	}
+	run_installer "jcode" "_run_jcode_install" "command -v jcode" "jcode --version 2>/dev/null || true"
+}

--- a/tests/pr_jcode.bats
+++ b/tests/pr_jcode.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+# Tests for jcode scaffolding
+
+load helpers
+
+REPO_ROOT="$BATS_TEST_DIRNAME/.."
+LIB_INSTALL="$REPO_ROOT/lib/install.sh"
+CLI_SH="$REPO_ROOT/cli.sh"
+GENERATE_SH="$REPO_ROOT/generate.sh"
+README="$REPO_ROOT/README.md"
+
+@test "configs/jcode/AGENTS.md exists" {
+    [ -f "$REPO_ROOT/configs/jcode/AGENTS.md" ]
+}
+
+@test "configs/jcode/mcp.json exists" {
+    [ -f "$REPO_ROOT/configs/jcode/mcp.json" ]
+}
+
+@test "configs/jcode/config.toml exists" {
+    [ -f "$REPO_ROOT/configs/jcode/config.toml" ]
+}
+
+@test "configs/jcode/mcp.json contains mcpServers key" {
+    require_jq
+    run jq -e '.mcpServers | type == "object"' "$REPO_ROOT/configs/jcode/mcp.json"
+    [ "$status" -eq 0 ]
+    [ "$output" = "true" ]
+}
+
+@test "configs/jcode/mcp.json mcpServers includes context7" {
+    require_jq
+    run jq -e '.mcpServers.context7.command == "npx"' "$REPO_ROOT/configs/jcode/mcp.json"
+    [ "$status" -eq 0 ]
+    [ "$output" = "true" ]
+}
+
+@test "configs/jcode ships curated skills" {
+    [ -f "$REPO_ROOT/configs/jcode/skills/code-reviewer/SKILL.md" ]
+    [ -f "$REPO_ROOT/configs/jcode/skills/test-generator/SKILL.md" ]
+}
+
+@test "lib/install.sh defines install_jcode()" {
+    run grep -E '^install_jcode\(\)' "$LIB_INSTALL"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "lib/install.sh install_jcode() prefers Homebrew tap when brew is available" {
+    run grep -E '1jehuang/jcode' "$LIB_INSTALL"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "lib/install.sh install_jcode() uses the official jcode.sh installer" {
+    run grep -E 'jcode\.sh/install' "$LIB_INSTALL"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "lib/install.sh install_jcode() handles Windows PowerShell install" {
+    run grep -E 'jcode\.sh/install\.ps1' "$LIB_INSTALL"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "cli.sh defines copy_jcode_configs()" {
+    run grep -E '^copy_jcode_configs\(\)' "$CLI_SH"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "cli.sh copy_configurations() calls copy_jcode_configs" {
+    run grep -E 'copy_jcode_configs' "$CLI_SH"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "cli.sh main() installs jcode" {
+    run grep -F '"jcode:install_jcode"' "$CLI_SH"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "cli.sh banner advertises jcode" {
+    run grep -E 'jcode' "$CLI_SH"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "cli.sh copy_jcode_configs() installs ~/AGENTS.md" {
+    run grep -E 'copy_config_file.*configs/jcode/AGENTS\.md.*HOME/' "$CLI_SH"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "cli.sh copy_jcode_configs() copies mcp.json into ~/.jcode/" {
+    run grep -E "copy_config_file.*configs/jcode/mcp\.json" "$CLI_SH"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "cli.sh copy_jcode_configs() targets ~/.jcode/" {
+    run grep -E 'HOME/\.jcode' "$CLI_SH"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "generate.sh defines generate_jcode_configs()" {
+    run grep -E '^generate_jcode_configs\(\)' "$GENERATE_SH"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "generate.sh generate_jcode_configs() exports mcp.json" {
+    run grep -E 'copy_single.*jcode/mcp\.json' "$GENERATE_SH"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "generate.sh generate_jcode_configs() exports ~/AGENTS.md" {
+    run grep -E 'copy_single.*HOME/AGENTS\.md.*configs/jcode/AGENTS\.md' "$GENERATE_SH"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "generate.sh main() invokes generate_jcode_configs" {
+    run grep -E '^\s*generate_jcode_configs\b' "$GENERATE_SH"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "README.md mentions jcode in the supported-tools list" {
+    run grep -E '\bjcode\b' "$README"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "README.md has a jcode section with a curl installer example" {
+    run grep -E 'jcode\.sh/install' "$README"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "README.md jcode section documents ~/AGENTS.md" {
+    run grep -E '~/AGENTS\.md' "$README"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}


### PR DESCRIPTION
## Summary
- Add `configs/jcode/` with `AGENTS.md` (→ `~/AGENTS.md`), `mcp.json`, `config.toml`, and curated skills
- Wire `install_jcode` into `lib/install.sh` / `INSTALL_SEQUENCE`, plus `copy_jcode_configs` / `generate_jcode_configs` mirroring Qoder/Kimi
- Document in README and cover with `tests/pr_jcode.bats`

## Test plan
- [x] `bash -n cli.sh generate.sh lib/*.sh`
- [x] `bats tests/pr_jcode.bats` (via microsandbox)
- [ ] `./cli.sh --dry-run` and confirm jcode install/copy steps appear
- [ ] `./cli.sh` on a machine with jcode installed; verify `~/AGENTS.md`, `~/.jcode/mcp.json`, and skills land
- [ ] `./generate.sh --dry-run` shows jcode export paths


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class jcode support, including installation through Homebrew, curl, or PowerShell.
  * Added bundled jcode configuration, MCP server settings, agent guidance, and curated skills.
  * Added automatic configuration backup, generation, validation, and installation for jcode.
  * Added documentation covering setup, configuration locations, authentication testing, and browser automation.
* **Tests**
  * Added coverage verifying jcode files, installer wiring, configuration handling, and documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->