### PR TITLE
feat(security-audit): comprehensive OWASP/ASVS/Node.js/DevSecOps skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -165,6 +165,17 @@
 			"category": "productivity"
 		},
 		{
+			"name": "security-audit",
+			"description": "Perform structured security audits using OWASP Top 10, ASVS, cheat sheets, framework checks, and DevSecOps controls.",
+			"version": "1.0.0",
+			"author": {
+				"name": "Dung Huynh Duc",
+				"email": "dung@productsway.com"
+			},
+			"source": "./skills/security-audit",
+			"category": "code-quality"
+		},
+		{
 			"name": "slop",
 			"description": "Removes AI-generated code slop from git diffs to maintain code quality. Clean up extra comments, defensive checks, type casts, and inconsistent style.",
 			"version": "1.0.0",

--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ npx skills add jellydn/my-ai-tools --yes --global --agent claude-code
 # Or install interactively (select which skills to install)
 npx skills add jellydn/my-ai-tools --global --agent claude-code
 
-# Available skills: prd, ralph, qmd-knowledge, codemap, adr, handoffs, pickup, pr-review, slop, tdd, code-quality-review, commit-atomic, draft-pull-request, docs-update, llm-wiki, plannotator-setup-goal, portless-local, tmux, blindspot-pass, implementation-logger, quiz-me, spec-interview, capability-experiments, code-review, context-discovery, doc-search, git-context, orchestrating-fusion
+# Available skills: prd, ralph, qmd-knowledge, codemap, adr, handoffs, pickup, pr-review, slop, tdd, code-quality-review, commit-atomic, draft-pull-request, docs-update, llm-wiki, plannotator-setup-goal, portless-local, security-audit, tmux, blindspot-pass, implementation-logger, quiz-me, spec-interview, capability-experiments, code-review, context-discovery, doc-search, git-context, orchestrating-fusion
 # Skills are installed to ~/.agents/skills/ with symlinks in ~/.claude/skills/
 ```
 
@@ -803,6 +803,7 @@ Located in [`configs/claude/agents/`](configs/claude/agents/):
 - `prd` - Generate Product Requirements Documents
 - `qmd-knowledge` - Project knowledge management
 - `ralph` - Convert PRDs to JSON for autonomous agent execution
+- `security-audit` - Structured security audit workflow using OWASP Top 10, ASVS, and DevSecOps controls
 - `slop` - AI slop detection and removal
 - `tdd` - Test-Driven Development workflows
 - `code-quality-review` - Extremely strict maintainability and structural code quality reviews

--- a/cli.sh
+++ b/cli.sh
@@ -2126,7 +2126,7 @@ install_single_recommended_skill() {
 # Helper: Check if a skill is in the remote/universal skills list
 is_remote_skill() {
 	case "$1" in
-	plannotator-setup-goal | prd | ralph | qmd-knowledge | codemap | adr | handoffs | pickup | pr-review | slop | tdd | commit-atomic | draft-pull-request)
+	plannotator-setup-goal | prd | ralph | qmd-knowledge | codemap | adr | handoffs | pickup | pr-review | slop | tdd | commit-atomic | draft-pull-request | security-audit)
 		return 0
 		;;
 	*)
@@ -2206,6 +2206,7 @@ enable_plugins() {
 		"codemap|codemap@my-ai-tools|$SCRIPT_DIR|claude"
 		"commit-atomic|commit-atomic@my-ai-tools|$SCRIPT_DIR|claude"
 		"draft-pull-request|draft-pull-request@my-ai-tools|$SCRIPT_DIR|claude"
+		"security-audit|security-audit@my-ai-tools|$SCRIPT_DIR|claude"
 		"claude-hud|claude-hud@claude-hud|jarrodwatts/claude-hud|claude"
 		"worktrunk|worktrunk@worktrunk|max-sixty/worktrunk|claude"
 		"openai-codex|codex@openai-codex|openai/codex-plugin-cc|claude"

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: security-audit
+description: "Audits code and architecture for security vulnerabilities using OWASP Top 10, ASVS, Cheat Sheet Series, Node.js best practices, and DevSecOps controls. Use when reviewing code for security issues, hardening an application, or planning security requirements."
+license: MIT
+compatibility: cline, claude, opencode, amp, codex, gemini, cursor, pi
+hint: Use when auditing code for security vulnerabilities or hardening an application
+user-invocable: true
+metadata:
+  audience: all
+  workflow: security
+---
+
+# Security Audit
+
+Perform a structured security audit of code, configuration, and architecture. Identify vulnerabilities, rank them by severity, and recommend concrete fixes grounded in OWASP standards, framework-specific best practices, and DevSecOps controls.
+
+This is a **read-only analysis**. Do not modify code — audit, then report.
+
+## Usage
+
+```bash
+/security-audit [scope]
+```
+
+- With no argument, audit the current branch's diff against the default branch.
+- With a path or module name, audit that scope.
+- Use `full` to audit the whole repository for systemic issues.
+
+## Knowledge Base
+
+The audit draws on five reference areas. Load the relevant reference file when a finding needs grounding or when you need detailed requirements for a topic:
+
+| Area | Reference | When to load |
+| --- | --- | --- |
+| OWASP Top 10 | `reference/owasp-top-10.md` | Classifying a finding against the major vulnerability categories (2021 + 2025) |
+| OWASP ASVS | `reference/owasp-asvs.md` | Deriving concrete security requirements or building a verification checklist |
+| OWASP Cheat Sheet Series | `reference/owasp-cheat-sheets.md` | Needing practical implementation guidance (auth, JWT, file upload, CSRF, password storage) |
+| Node.js Security | `reference/nodejs-security.md` | Auditing Express, NestJS, Fastify, or Node.js dependency/supply-chain issues |
+| DevSecOps | `reference/devsecops.md` | Reviewing CI/CD pipeline security, dependency/container/secret/SAST/DAST scanning |
+
+Use progressive disclosure: keep the reference files unloaded until a finding maps to them. Load only the file the current finding needs.
+
+## Audit Process
+
+### 1. Scope and gather context
+
+```bash
+# Detect the default branch
+BASE_BRANCH=$(git remote show origin 2>/dev/null | grep 'HEAD branch' | awk '{print $NF}' || echo main)
+
+# Diff under audit
+git diff "$BASE_BRANCH"...HEAD --stat
+git diff "$BASE_BRANCH"...HEAD
+
+# Dependency surface
+cat package.json 2>/dev/null | jq '.dependencies, .devDependencies'
+npm audit --json 2>/dev/null | jq '.metadata.vulnerabilities' 2>/dev/null
+
+# Configuration surface
+find . -maxdepth 2 \( -name '*.yml' -o -name '*.yaml' -o -name 'Dockerfile*' -o -name '.env*' \) -not -path './node_modules/*'
+```
+
+For a full audit, also enumerate: auth/session code, input handlers, file upload paths, database query construction, crypto usage, CI/CD workflow files, and container definitions.
+
+### 2. Run the checklist
+
+Walk every changed or in-scope file against this checklist. Each item maps to an OWASP Top 10 category — use `reference/owasp-top-10.md` for the full category definitions and examples.
+
+#### Input validation & injection (A03 Injection, A02 Crypto Failures)
+- [ ] All external input (body, query, params, headers, cookies) is validated with an allow-list schema (zod, joi, ajv, class-validator)
+- [ ] SQL/NoSQL queries use parameterized queries or ORM builders — no string concatenation
+- [ ] OS command execution avoids `exec`/`spawn` with user input; uses argument arrays
+- [ ] Output encoding is applied contextually (HTML, JS, URL, CSS) to prevent XSS
+- [ ] Template engines use auto-escaping; `dangerouslySetInnerHTML`/`v-html`/`|raw` justified and sanitized
+- [ ] Path traversal prevented — user input never reaches file path construction unsanitized
+- [ ] SSRF prevented — outbound URLs validated against an allow-list, internal IPs blocked
+
+#### Authentication & session (A07 Auth Failures)
+- [ ] Passwords hashed with bcrypt/argon2/scrypt — never MD5/SHA1/plain text
+- [ ] MFA available; credential recovery does not leak account existence
+- [ ] Session IDs are high-entropy, rotated on login, invalidated on logout
+- [ ] JWTs (if used) verified for signature, expiry, audience; secrets strong and rotated — see `reference/owasp-cheat-sheets.md`
+- [ ] Brute-force protection (rate limiting, lockout) on auth endpoints
+- [ ] No default or weak credentials
+
+#### Authorization & access control (A01 Broken Access Control)
+- [ ] Deny by default; explicit allow on every protected resource
+- [ ] Object-level (IDOR) checks — user cannot access other users' records by ID
+- [ ] Role checks at the right layer (middleware/guard), not scattered in handlers
+- [ ] No privilege escalation paths; admin functions gated
+- [ ] CORS configured with an explicit origin allow-list — never `*` with credentials
+
+#### Data protection & cryptography (A02 Cryptographic Failures, A08 Integrity Failures)
+- [ ] TLS enforced everywhere; HSTS enabled; weak ciphers disabled
+- [ ] Sensitive data encrypted at rest; secrets in a vault/env, never committed
+- [ ] No sensitive data in logs, error messages, or URLs
+- [ ] Strong algorithms only (AES-GCM, ChaCha20); no deprecated crypto (DES, RC4, ECB)
+- [ ] Random values use `crypto.randomUUID()`/`crypto.randomBytes()` — never `Math.random()` for security
+- [ ] Deserialization of untrusted data avoided or integrity-checked
+
+#### Configuration & dependencies (A05 Security Misconfiguration, A03 Supply Chain, A06 Insecure Design)
+- [ ] No hardcoded secrets, tokens, or API keys — see `reference/devsecops.md` for secret scanning
+- [ ] Debug/verbose error pages disabled in production; stack traces not exposed
+- [ ] Security headers present (CSP, HSTS, X-Frame-Options, X-Content-Type-Options) — helmet/ equivalents
+- [ ] Dependencies pinned and audited; no known high/critical CVEs
+- [ ] `npm ci` used in CI; lockfile committed; `--ignore-scripts` considered
+- [ ] File uploads validated (type, size, content); stored outside web root — see `reference/owasp-cheat-sheets.md`
+- [ ] Rate limiting on API and auth endpoints
+
+#### Logging & error handling (A09 Logging Failures, A10 Mishandling Exceptional Conditions)
+- [ ] Security events logged (auth failures, access denials, input validation failures)
+- [ ] Logs do not contain passwords, tokens, or PII
+- [ ] Errors fail closed (deny) not open (allow) on unexpected conditions
+- [ ] Generic error messages to users; details server-side only
+- [ ] NULL/missing-parameter paths handled, not crashing or leaking info
+
+### 3. Framework-specific checks
+
+For Node.js projects, load `reference/nodejs-security.md` and check framework-specific concerns:
+
+- **Express**: `helmet()`, `express-rate-limit`, `cors` allow-list, no `X-Powered-By`, body size limits, prototype pollution defenses
+- **NestJS**: `ValidationPipe` with `whitelist` + `forbidNonWhitelisted`, `ClassSerializerInterceptor` to strip sensitive fields, Guards for authz, `helmet` middleware, throttler
+- **Fastify**: `@fastify/helmet`, `@fastify/rate-limit`, `@fastify/cors` with origin allow-list, schema validation on routes, `@fastify/under-pressure`
+- **All**: dependency pinning, `npm audit`/Snyk/Socket, non-root container user, event-loop blocking (ReDoS, sync APIs), prototype pollution
+
+### 4. Pipeline & deployment checks
+
+When the scope includes CI/CD or deployment, load `reference/devsecops.md` and verify:
+
+- [ ] Dependency scanning (npm audit / Snyk / Dependabot / Trivy) runs in CI and gates on high/critical
+- [ ] Secret scanning (Gitleaks pre-commit, TruffleHog in CI) prevents leaked credentials
+- [ ] Container scanning (Trivy / Grype) on built images; base image minimal (distroless/slim)
+- [ ] SAST (Semgrep / CodeQL) runs on PRs; results triaged
+- [ ] DAST (OWASP ZAP) against staging on deploys
+- [ ] IaC scanning (Checkov / tfsec) on Terraform/K8s manifests
+- [ ] Least privilege: non-root container, read-only FS, dropped capabilities
+- [ ] SBOM generated (CycloneDX / SPDX) for supply-chain traceability
+
+### 5. Rank findings and report
+
+#### Severity
+
+| Level | Criteria | Examples |
+| --- | --- | --- |
+| 🔴 Critical | Immediate, exploitable risk | SQL injection, RCE, exposed secrets, broken auth |
+| 🟠 High | Significant concern, likely exploitable | auth bypass, IDOR, missing authz on sensitive data |
+| 🟡 Medium | Potential vulnerability | missing validation, weak crypto, verbose errors |
+| 🟢 Low | Defense-in-depth improvement | missing security header, better logging |
+| ℹ️ Info | Awareness note | version end-of-life, future hardening |
+
+#### Output format
+
+```markdown
+## Executive Summary
+
+- Overall posture: Secure / Needs attention / Critical issues
+- N findings: 🔴 x  🟠 x  🟡 x  🟢 x  ℹ️ x
+- Top recommendations (ordered by impact)
+
+## Findings
+
+### [Severity] Title
+- **OWASP**: A03:2021-Injection (and A05:2025 if reclassified)
+- **Location**: `src/api/upload.ts:42`
+- **Issue**: One-line description
+- **Impact**: What an attacker can do
+- **Recommendation**: Concrete fix with code snippet or config change
+- **Reference**: OWASP Cheat Sheet — File Upload; ASVS v5.0.0-5.2.1
+
+## Positive Practices
+
+- Well-implemented controls worth keeping
+```
+
+Cite the relevant OWASP category, ASVS requirement ID (e.g. `v5.0.0-6.2.3`), and Cheat Sheet in each finding so the recommendation is traceable to a standard.
+
+## Guidelines
+
+- **Be concrete**: every finding needs a fix the developer can act on, not just a description of the problem.
+- **Map to standards**: cite the OWASP Top 10 category and, where relevant, the ASVS requirement ID and Cheat Sheet. This makes findings auditable and educational.
+- **Verify, don't assume**: read the actual code before flagging. A pattern that looks vulnerable may be mitigated elsewhere — confirm the mitigation is missing before reporting.
+- **Prioritize by exploitability**: a Critical finding that requires no auth and is internet-reachable outranks a theoretical issue behind admin auth.
+- **Stay read-only**: never modify code during an audit. Use `execute()`-wrapped commands only for inspection (`git diff`, `npm audit`, `cat`, `grep`).
+- **Note the version**: when citing OWASP Top 10, state whether you are using the 2021 or 2025 edition — they differ (see `reference/owasp-top-10.md`).

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -62,11 +62,16 @@ find . -maxdepth 2 \( -name '*.yml' -o -name '*.yaml' -o -name 'Dockerfile*' -o 
 
 For a full audit, also enumerate: auth/session code, input handlers, file upload paths, database query construction, crypto usage, CI/CD workflow files, and container definitions.
 
+Completion criteria:
+- Default branch and diff under audit are identified.
+- Dependency and configuration surfaces are enumerated for the selected scope.
+- For `full` audits, the additional security-critical code paths are listed.
+
 ### 2. Run the checklist
 
 Walk every changed or in-scope file against this checklist. Each item maps to an OWASP Top 10 category — use `reference/owasp-top-10.md` for the full category definitions and examples.
 
-#### Input validation & injection (A03 Injection, A02 Crypto Failures)
+#### Input validation & injection (A03:2021 Injection, A05:2025 Injection; A02:2021 Cryptographic Failures, A04:2025 Cryptographic Failures)
 - [ ] All external input (body, query, params, headers, cookies) is validated with an allow-list schema (zod, joi, ajv, class-validator)
 - [ ] SQL/NoSQL queries use parameterized queries or ORM builders — no string concatenation
 - [ ] OS command execution avoids `exec`/`spawn` with user input; uses argument arrays
@@ -75,7 +80,7 @@ Walk every changed or in-scope file against this checklist. Each item maps to an
 - [ ] Path traversal prevented — user input never reaches file path construction unsanitized
 - [ ] SSRF prevented — outbound URLs validated against an allow-list, internal IPs blocked
 
-#### Authentication & session (A07 Auth Failures)
+#### Authentication & session (A07:2021 Identification and Authentication Failures, A07:2025 Authentication Failures)
 - [ ] Passwords hashed with bcrypt/argon2/scrypt — never MD5/SHA1/plain text
 - [ ] MFA available; credential recovery does not leak account existence
 - [ ] Session IDs are high-entropy, rotated on login, invalidated on logout
@@ -83,14 +88,14 @@ Walk every changed or in-scope file against this checklist. Each item maps to an
 - [ ] Brute-force protection (rate limiting, lockout) on auth endpoints
 - [ ] No default or weak credentials
 
-#### Authorization & access control (A01 Broken Access Control)
+#### Authorization & access control (A01:2021 Broken Access Control, A01:2025 Broken Access Control)
 - [ ] Deny by default; explicit allow on every protected resource
 - [ ] Object-level (IDOR) checks — user cannot access other users' records by ID
 - [ ] Role checks at the right layer (middleware/guard), not scattered in handlers
 - [ ] No privilege escalation paths; admin functions gated
 - [ ] CORS configured with an explicit origin allow-list — never `*` with credentials
 
-#### Data protection & cryptography (A02 Cryptographic Failures, A08 Integrity Failures)
+#### Data protection & cryptography (A02:2021 Cryptographic Failures, A04:2025 Cryptographic Failures; A08:2021/2025 Software and Data Integrity Failures)
 - [ ] TLS enforced everywhere; HSTS enabled; weak ciphers disabled
 - [ ] Sensitive data encrypted at rest; secrets in a vault/env, never committed
 - [ ] No sensitive data in logs, error messages, or URLs
@@ -98,7 +103,7 @@ Walk every changed or in-scope file against this checklist. Each item maps to an
 - [ ] Random values use `crypto.randomUUID()`/`crypto.randomBytes()` — never `Math.random()` for security
 - [ ] Deserialization of untrusted data avoided or integrity-checked
 
-#### Configuration & dependencies (A05 Security Misconfiguration, A03 Supply Chain, A06 Insecure Design)
+#### Configuration & dependencies (A05:2021 Security Misconfiguration, A02:2025 Security Misconfiguration; A06:2021 Vulnerable and Outdated Components, A03:2025 Software Supply Chain Failures; A04:2021/A06:2025 Insecure Design)
 - [ ] No hardcoded secrets, tokens, or API keys — see `reference/devsecops.md` for secret scanning
 - [ ] Debug/verbose error pages disabled in production; stack traces not exposed
 - [ ] Security headers present (CSP, HSTS, X-Frame-Options, X-Content-Type-Options) — helmet/ equivalents
@@ -107,12 +112,16 @@ Walk every changed or in-scope file against this checklist. Each item maps to an
 - [ ] File uploads validated (type, size, content); stored outside web root — see `reference/owasp-cheat-sheets.md`
 - [ ] Rate limiting on API and auth endpoints
 
-#### Logging & error handling (A09 Logging Failures, A10 Mishandling Exceptional Conditions)
+#### Logging & error handling (A09:2021 Security Logging and Monitoring Failures, A09:2025 Security Logging and Alerting Failures; A10:2025 Mishandling of Exceptional Conditions)
 - [ ] Security events logged (auth failures, access denials, input validation failures)
 - [ ] Logs do not contain passwords, tokens, or PII
 - [ ] Errors fail closed (deny) not open (allow) on unexpected conditions
 - [ ] Generic error messages to users; details server-side only
 - [ ] NULL/missing-parameter paths handled, not crashing or leaking info
+
+Completion criteria:
+- Every changed or in-scope file is checked against all relevant checklist sections.
+- Each unchecked item is either confirmed not applicable or recorded as a finding.
 
 ### 3. Framework-specific checks
 
@@ -122,6 +131,10 @@ For Node.js projects, load `reference/nodejs-security.md` and check framework-sp
 - **NestJS**: `ValidationPipe` with `whitelist` + `forbidNonWhitelisted`, `ClassSerializerInterceptor` to strip sensitive fields, Guards for authz, `helmet` middleware, throttler
 - **Fastify**: `@fastify/helmet`, `@fastify/rate-limit`, `@fastify/cors` with origin allow-list, schema validation on routes, `@fastify/under-pressure`
 - **All**: dependency pinning, `npm audit`/Snyk/Socket, non-root container user, event-loop blocking (ReDoS, sync APIs), prototype pollution
+
+Completion criteria:
+- The active framework stack is identified.
+- Matching framework checks are reviewed and any gaps are captured as findings.
 
 ### 4. Pipeline & deployment checks
 
@@ -135,6 +148,10 @@ When the scope includes CI/CD or deployment, load `reference/devsecops.md` and v
 - [ ] IaC scanning (Checkov / tfsec) on Terraform/K8s manifests
 - [ ] Least privilege: non-root container, read-only FS, dropped capabilities
 - [ ] SBOM generated (CycloneDX / SPDX) for supply-chain traceability
+
+Completion criteria:
+- CI/CD and deployment controls in scope are reviewed against this checklist.
+- Missing controls are documented with severity and remediation guidance.
 
 ### 5. Rank findings and report
 
@@ -174,11 +191,15 @@ When the scope includes CI/CD or deployment, load `reference/devsecops.md` and v
 
 Cite the relevant OWASP category, ASVS requirement ID (e.g. `v5.0.0-6.2.3`), and Cheat Sheet in each finding so the recommendation is traceable to a standard.
 
+Completion criteria:
+- Every finding has severity, location, impact, recommendation, and standard references.
+- Executive summary totals match the findings list.
+
 ## Guidelines
 
 - **Be concrete**: every finding needs a fix the developer can act on, not just a description of the problem.
 - **Map to standards**: cite the OWASP Top 10 category and, where relevant, the ASVS requirement ID and Cheat Sheet. This makes findings auditable and educational.
 - **Verify, don't assume**: read the actual code before flagging. A pattern that looks vulnerable may be mitigated elsewhere — confirm the mitigation is missing before reporting.
 - **Prioritize by exploitability**: a Critical finding that requires no auth and is internet-reachable outranks a theoretical issue behind admin auth.
-- **Stay read-only**: never modify code during an audit. Use `execute()`-wrapped commands only for inspection (`git diff`, `npm audit`, `cat`, `grep`).
+- **Stay read-only**: never modify code during an audit. Use inspection-only commands (`git diff`, `npm audit`, `cat`, `grep`). If your environment provides an `execute()` wrapper, prefer it for read-only command execution.
 - **Note the version**: when citing OWASP Top 10, state whether you are using the 2021 or 2025 edition — they differ (see `reference/owasp-top-10.md`).

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-audit
-description: "Audits code and architecture for security vulnerabilities using OWASP Top 10, ASVS, Cheat Sheet Series, Node.js best practices, and DevSecOps controls. Use when reviewing code for security issues, hardening an application, or planning security requirements."
+description: "Use when reviewing code for security vulnerabilities, hardening an application, or deriving security requirements from OWASP/ASVS guidance."
 license: MIT
 compatibility: cline, claude, opencode, amp, codex, gemini, cursor, pi
 hint: Use when auditing code for security vulnerabilities or hardening an application

--- a/skills/security-audit/reference/devsecops.md
+++ b/skills/security-audit/reference/devsecops.md
@@ -1,0 +1,160 @@
+# DevSecOps — Integrating Security into CI/CD
+
+DevSecOps shifts security left: automated scanning in the pipeline catches vulnerabilities before production, with fast developer feedback and security gates that block rather than just warn. Use this reference when auditing CI/CD workflows, GitHub Actions, GitLab CI, Dockerfiles, or IaC.
+
+## The pipeline security flow
+
+```
+Code Push
+  ├─ Secret scanning (pre-commit) ─┐
+  ├─ SAST (source) ────────────────┤
+  ├─ Dependency scanning (SCA) ────┤
+                                  Build
+                                   ├─ Container scanning ──┐
+                                   ├─ IaC scanning ────────┤
+                                                          Deploy to staging
+                                                           └─ DAST (running app) → gate → prod
+```
+
+Run fast feedback (secrets, SAST, deps) on every PR; slower/deeper scans (full DAST, nightly audit) on schedule or main.
+
+## Scanning categories & tools
+
+### 1. Dependency scanning (SCA — Software Composition Analysis)
+Identifies known CVEs in third-party dependencies by comparing versions against vulnerability databases (NVD, OSV, GitHub Advisory DB).
+
+| Tool | Fit |
+| --- | --- |
+| `npm audit` | Built-in; baseline for Node. `--audit-level=high` to gate. |
+| GitHub Dependabot | Native PR alerts + auto-upgrade PRs. Configure `dependabot.yml`. |
+| Snyk | Deep CVE DB, reachability, auto-fix PRs, container + IaC too. |
+| Trivy (`trivy fs`) | OSS; filesystem/lockfile scan; fast. |
+| OWASP Dependency-Check | OSS; multi-ecosystem. |
+| Socket.dev | Static analysis of package *behavior* (network/fs access) — catches malware, not just CVEs. |
+
+Gate on high/critical; require lockfiles for accurate transitive resolution.
+
+### 2. Secret detection
+Scans code, git history, and config for leaked credentials (API keys, tokens, private keys).
+
+| Tool | Fit |
+| --- | --- |
+| Gitleaks | OSS, fast, Go binary. Best as a **pre-commit hook** (sub-second). SARIF output for GitHub. |
+| TruffleHog | OSS; **verifies** whether detected secrets are still active. Best in **CI/CD** for triaged, verified findings. Scans Docker images, S3. |
+| GitHub secret scanning + push protection | Native; blocks secrets before commit (Enterprise). |
+| GitGuardian | Enterprise; broad coverage + remediation workflow. |
+
+Recommended pattern: **Gitleaks pre-commit** (speed) + **TruffleHog in CI** (verified depth). Custom rules for internal token formats; entropy detection for unknown patterns.
+
+### 3. SAST (Static Application Security Testing)
+Analyzes source code for vulnerability patterns without running it.
+
+| Tool | Fit |
+| --- | --- |
+| Semgrep | OSS; pattern-based, fast, custom rules, low false positives. Multi-language. |
+| GitHub CodeQL | OSS for OSS repos; semantic dataflow analysis; deep. |
+| SonarQube | Quality + security gates; CI integration. |
+| Snyk Code | SAST with reachability + fix suggestions. |
+| Checkmarx / Veracode | Enterprise; deep taint analysis. |
+
+SAST catches injection, hardcoded secrets, weak crypto, missing validation. Pattern-based tools (Semgrep) miss complex interprocedural dataflow — supplement with CodeQL or a commercial tool for complex apps. Tune to reduce false positives or developers ignore findings.
+
+### 4. DAST (Dynamic Application Security Testing)
+Tests a **running** application by sending real HTTP requests — finds runtime issues SAST misses (auth bypass, reflected XSS, misconfigured headers).
+
+| Tool | Fit |
+| --- | --- |
+| OWASP ZAP | OSS; the standard. Active/passive scan; API scan via OpenAPI; authenticated scans. |
+| GitLab DAST | ZAP-based; integrated template. |
+| Nuclei | OSS; template-based, fast, community templates. |
+
+Run DAST against staging/review apps post-deploy. **Authenticated DAST** (provide login flow) finds far more than unauthenticated. Point at an ephemeral review app per PR for shift-left DAST.
+
+### 5. Container scanning
+Scans Docker images for OS-level CVEs (base image packages) and app-level vulnerabilities.
+
+| Tool | Fit |
+| --- | --- |
+| Trivy (`trivy image`) | OSS; the standard. Fast; vuln + secret + misconfig. |
+| Grype | OSS; fast SBOM-based vuln matching. |
+| Snyk Container | Deep DB + fix PRs. |
+| Aqua / Black Duck | Enterprise. |
+
+The biggest lever is often the **base image**: switch `ubuntu:22.04` → `gcr.io/distroless/base` or `debian:bookworm-slim` to remove hundreds of unused-package CVEs. Rebuild regularly to pick up upstream patches. Run as non-root, read-only FS, dropped capabilities.
+
+### 6. IaC scanning
+Scans Terraform, CloudFormation, K8s manifests, Helm charts for misconfigurations.
+
+| Tool | Fit |
+| --- | --- |
+| Checkov | OSS; broad IaC + cloud misconfig. |
+| tfsec / Trivy IaC | OSS; Terraform-focused. |
+| KICS | OSS; multi-IaC. |
+| OPA / Gatekeeper | Policy-as-code; admission control in K8s. |
+
+## CI/CD security gates (audit checklist)
+
+- [ ] **Pre-commit**: Gitleaks hook blocks secrets locally before push
+- [ ] **PR pipeline**: SAST (Semgrep/CodeQL) + dependency scan + secret scan run on every PR
+- [ ] **Build**: image built, then container scan (Trivy) gates on high/critical
+- [ ] **IaC**: Checkov/tfsec runs on infra PRs
+- [ ] **Deploy to staging**: ephemeral review app; DAST (ZAP authenticated) runs post-deploy
+- [ ] **Gate policy**: new critical/high findings block merge; pre-existing findings tracked, not blocking
+- [ ] **SBOM**: CycloneDX/SPDX generated and stored per release for supply-chain traceability
+- [ ] **Least privilege**: CI runner tokens scoped; deploy keys per-repo; no broad PATs; secrets in OIDC/Vault not env vars in logs
+- [ ] **Scheduled deep scan**: nightly full SAST + full dependency + container scan on main
+- [ ] **Findings routed**: SARIF uploaded to GitHub Security tab or a dashboard; auto-ticketed; owners assigned
+
+## GitHub Actions example (Node.js)
+
+```yaml
+# .github/workflows/security.yml
+name: Security
+on: [pull_request]
+jobs:
+  secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+      - uses: gitleaks/gitleaks-action@v2
+  sast:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: returntocorp/semgrep-action@v1
+  deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: "24" }
+      - run: npm ci --ignore-scripts
+      - run: npm audit --audit-level=high
+  container:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ needs.build.outputs.image }}
+          severity: HIGH,CRITICAL
+          exit-code: "1"
+```
+
+## Hardening the pipeline itself
+- Pin actions to a commit SHA, not a floating tag (`@v4` can be hijacked).
+- Use OIDC for cloud deploys instead of long-lived secrets.
+- Restrict `pull_request_target` usage (it runs with secrets — dangerous with untrusted PRs).
+- Limit `GITHUB_TOKEN` permissions to read-only by default; escalate per-job.
+- Audit third-party actions for network calls and credential access.
+
+## References
+- OWASP DevSecOps Guideline — https://owasp.org/www-project-devsecops-guideline/
+- OWASP DevSecOps Maturity Model — https://dsomm.owasp.org/
+- Trivy — https://github.com/aquasecurity/trivy
+- Semgrep — https://semgrep.dev/
+- Gitleaks — https://github.com/gitleaks/gitleaks
+- TruffleHog — https://github.com/trufflesecurity/trufflehog
+- OWASP ZAP — https://www.zaproxy.org/
+- GitHub Security hardening — https://docs.github.com/en/actions/security-guides

--- a/skills/security-audit/reference/devsecops.md
+++ b/skills/security-audit/reference/devsecops.md
@@ -4,7 +4,7 @@ DevSecOps shifts security left: automated scanning in the pipeline catches vulne
 
 ## The pipeline security flow
 
-```
+```text
 Code Push
   ├─ Secret scanning (pre-commit) ─┐
   ├─ SAST (source) ────────────────┤
@@ -115,29 +115,28 @@ jobs:
   secrets:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with: { fetch-depth: 0 }
-      - uses: gitleaks/gitleaks-action@v2
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
   sast:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: returntocorp/semgrep-action@v1
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: returntocorp/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d
   deps:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with: { node-version: "24" }
       - run: npm ci --ignore-scripts
       - run: npm audit --audit-level=high
   container:
     runs-on: ubuntu-latest
-    needs: build
     steps:
-      - uses: aquasecurity/trivy-action@master
+      - uses: aquasecurity/trivy-action@2736533278103862a861f4a35ebac3e97854d956
         with:
-          image-ref: ${{ needs.build.outputs.image }}
+          image-ref: node:24-alpine
           severity: HIGH,CRITICAL
           exit-code: "1"
 ```

--- a/skills/security-audit/reference/nodejs-security.md
+++ b/skills/security-audit/reference/nodejs-security.md
@@ -1,0 +1,159 @@
+# Node.js Security Best Practices
+
+Framework-specific security guidance for Node.js applications (Express, NestJS, Fastify) and dependency/supply-chain management. Node.js ships with **no security defaults** — every protection must be added explicitly.
+
+## Universal Node.js concerns
+
+### Event loop & DoS
+- **ReDoS**: the single-threaded event loop means one slow regex stalls every request. Audit regexes for catastrophic backtracking; use `safe-regex`/`re2`; bound input length.
+- **Blocking the loop**: avoid sync APIs (`fs.readFileSync`, `crypto.pbkdf2Sync`, `zlib.inflateSync`) in request paths. Offload CPU-bound work to worker threads.
+- **HTTP server timeouts**: set `headersTimeout`, `requestTimeout`, `keepAliveTimeout`; limit `maxSockets`. Use a reverse proxy (nginx, CDN) for load balancing and IP throttling.
+- **Request body size limits**: configure `express.json({ limit: '100kb' })` / Fastify `bodyLimit` to prevent memory-exhaustion DoS.
+
+### Prototype pollution
+- Never `Object.assign`/`merge`/`extend` user-controlled JSON onto objects. `JSON.parse('{"__proto__":{"polluted":true}}')` followed by a merge pollutes prototypes.
+- Use `Object.create(null)` for lookup objects; strip `__proto__`, `constructor`, `prototype` keys; validate with zod/joi `stripUnknown`.
+- Audit `deepmerge`, `lodash.set`, `lodash.merge` versions for known prototype-pollution CVEs.
+
+### Unsafe APIs
+- Avoid `eval`, `Function()`, `vm.runInNewContext` with any user input.
+- `child_process.exec` shells the command — use `execFile`/`spawn` with argument arrays, never interpolated user input.
+- `path.join`/`path.resolve` with user input enables traversal — normalize and verify the result stays within an allowed root.
+
+### Cryptography
+- Passwords: `bcrypt`, `argon2`, or `scrypt` — never `crypto.createHash('md5'|'sha1')`.
+- Random: `crypto.randomUUID()`, `crypto.randomBytes()` — never `Math.random()` for tokens, IDs, or secrets.
+- Secrets/keys: load from env or a vault; never hardcode. Use `crypto.timingSafeEqual` for constant-time comparisons (e.g. HMAC verification).
+
+### Error handling
+- Centralized error middleware; never leak stack traces or internal messages to clients.
+- Fail **closed** (deny) on unexpected errors in authz middleware, not open (allow).
+- Use `try/catch` around `await`; unhandled rejections crash the process (or silently drop in newer Node — handle them).
+
+## Express
+
+```js
+const express = require("express");
+const helmet = require("helmet");
+const rateLimit = require("express-rate-limit");
+const cors = require("cors");
+
+const app = express();
+app.use(helmet());                          // security headers: CSP, HSTS, X-Frame-Options, etc.
+app.disable("x-powered-by");                // reduce fingerprinting
+app.use(express.json({ limit: "100kb" }));  // body size limit
+
+// CORS allow-list — never origin: '*' with credentials
+app.use(cors({
+  origin: ["https://app.example.com"],
+  credentials: true,
+  methods: ["GET", "POST", "PUT", "PATCH", "DELETE"],
+}));
+
+// Global rate limit
+app.use(rateLimit({ windowMs: 15 * 60 * 1000, max: 100, standardHeaders: true, legacyHeaders: false }));
+
+// Strict limit on auth
+app.use("/api/auth", rateLimit({ windowMs: 15 * 60 * 1000, max: 10, skipSuccessfulRequests: true }));
+```
+
+Audit checklist (Express):
+- [ ] `helmet()` applied early
+- [ ] `express-rate-limit` global + stricter on `/auth`, `/password-reset`
+- [ ] `cors` with explicit origin array (never `*` + `credentials: true`)
+- [ ] Body size limits (`limit` on `express.json`/`urlencoded`)
+- [ ] Cookie security: `httpOnly`, `secure`, `sameSite` flags; no default session name
+- [ ] Input validation via `express-validator`/`zod` at every route
+- [ ] Parameterized DB queries (Knex/Sequelize/Prisma) — no raw string SQL
+- [ ] Custom 404 and error handlers replacing Express defaults
+
+## NestJS
+
+```ts
+// main.ts
+import { NestFactory } from "@nestjs/core";
+import helmet from "helmet";
+import { ValidationPipe } from "@nestjs/common";
+
+const app = await NestFactory.create(AppModule);
+app.use(helmet());
+app.useGlobalPipes(new ValidationPipe({
+  whitelist: true,            // strip non-DTO properties
+  forbidNonWhitelisted: true, // reject unknown properties
+  transform: true,
+}));
+app.enableCors({ origin: ["https://app.example.com"], credentials: true });
+app.use((req, res, next) => { /* rate limit via @nestjs/throttler instead */ next(); });
+await app.listen(3000);
+```
+
+Audit checklist (NestJS):
+- [ ] `ValidationPipe` with `whitelist` + `forbidNonWhitelisted` globally
+- [ ] `@UseGuards(AuthGuard)` on protected routes; `@Roles()` + `RolesGuard` for authz
+- [ ] `ClassSerializerInterceptor` to strip `@Exclude()`-d sensitive fields from responses
+- [ ] `@nestjs/throttler` for rate limiting
+- [ ] `helmet` middleware; CORS with allow-list
+- [ ] No secrets in config files committed to repo — use `@nestjs/config` with env validation
+- [ ] DTOs on every input boundary; no raw `req.body` access
+
+## Fastify
+
+```ts
+import Fastify from "fastify";
+import helmet from "@fastify/helmet";
+import rateLimit from "@fastify/rate-limit";
+import cors from "@fastify/cors";
+
+const app = Fastify({ logger: true, bodyLimit: 100_000 });
+await app.register(helmet);
+await app.register(rateLimit, { max: 100, timeWindow: "15 minutes" });
+await app.register(cors, {
+  origin: ["https://app.example.com"],
+  credentials: true,
+});
+
+// Schema validation built into route declarations
+app.post("/users", {
+  schema: {
+    body: {
+      type: "object",
+      required: ["email", "password"],
+      properties: {
+        email: { type: "string", format: "email" },
+        password: { type: "string", minLength: 12 },
+      },
+      additionalProperties: false,
+    },
+  },
+  handler: async (req, reply) => { /* ... */ },
+});
+```
+
+Audit checklist (Fastify):
+- [ ] `@fastify/helmet`, `@fastify/rate-limit`, `@fastify/cors` with origin allow-list
+- [ ] JSON schema validation on every route (`body`, `querystring`, `params`, `headers`) with `additionalProperties: false`
+- [ ] `bodyLimit` set to a sane cap
+- [ ] `@fastify/under-pressure` for event-loop/memory pressure shedding
+- [ ] `@fastify/cookie` with `secure`/`httpOnly`/`sameSite` for session cookies
+- [ ] No `reply.send(user)` leaking sensitive fields — use serialization schemas
+
+## Dependency & supply-chain management
+
+- **Pin versions**: exact versions in `package.json` (not `^`/`~`); commit the lockfile (`package-lock.json`/`pnpm-lock.yaml`).
+- **CI install**: `npm ci` (fails on lockfile drift) instead of `npm install`.
+- **Audit**: `npm audit --audit-level=high` in CI; `npx snyk test` or Socket.dev for deeper analysis.
+- **Scripts**: disable install scripts with `npm config set ignore-scripts true` / `--ignore-scripts` to block malicious postinstall.
+- **Lockfile poisoning**: verify lockfile integrity; don't accept unreviewed lockfile changes in PRs.
+- **Typosquatting**: verify package names exactly; prefer scoped packages; review new dependencies.
+- **EOL runtimes**: stay on an active LTS line. Node 20.x EOL Apr 2026; 24.x is current LTS. Running EOL means unpatched CVEs.
+- **Reachability**: a CVE in a transitive dep is only critical if the vulnerable code path is reachable — use `npm audit` + Snyk/Socket reachability or `vet` to prioritize.
+- **Non-root container**: run the Node process as a non-root user; read-only FS where possible; drop Linux capabilities.
+- **Node.js permission model**: `--permission` flag restricts fs/net/child-process access — useful to contain compromised deps (still experimental; one layer among several).
+
+## References
+- Node.js security best practices — https://nodejs.org/learn/getting-started/security-best-practices
+- Node.js threat model — https://github.com/nodejs/node/security/policy
+- Express production security — https://expressjs.com/en/advanced/best-practice-security.html
+- Node.js Best Practices repo — https://github.com/goldbergyoni/nodebestpractices
+- Helmet — https://helmetjs.github.io/
+- Snyk Node.js guide — https://snyk.io/articles/nodejs-security-best-practice/

--- a/skills/security-audit/reference/nodejs-security.md
+++ b/skills/security-audit/reference/nodejs-security.md
@@ -145,7 +145,7 @@ Audit checklist (Fastify):
 - **Scripts**: disable install scripts with `npm config set ignore-scripts true` / `--ignore-scripts` to block malicious postinstall.
 - **Lockfile poisoning**: verify lockfile integrity; don't accept unreviewed lockfile changes in PRs.
 - **Typosquatting**: verify package names exactly; prefer scoped packages; review new dependencies.
-- **EOL runtimes**: stay on an active LTS line. Node 20.x EOL Apr 2026; 24.x is current LTS. Running EOL means unpatched CVEs.
+- **EOL runtimes**: stay on an active LTS line and verify support status against the official Node.js release schedule: https://nodejs.org/en/about/previous-releases. Running EOL means unpatched CVEs.
 - **Reachability**: a CVE in a transitive dep is only critical if the vulnerable code path is reachable — use `npm audit` + Snyk/Socket reachability or `vet` to prioritize.
 - **Non-root container**: run the Node process as a non-root user; read-only FS where possible; drop Linux capabilities.
 - **Node.js permission model**: `--permission` flag restricts fs/net/child-process access — useful to contain compromised deps (still experimental; one layer among several).

--- a/skills/security-audit/reference/owasp-asvs.md
+++ b/skills/security-audit/reference/owasp-asvs.md
@@ -1,0 +1,60 @@
+# OWASP ASVS — Application Security Verification Standard
+
+ASVS defines **what to verify** in an application to demonstrate real security assurance. Unlike the Top 10 (which lists risks), ASVS gives concrete, testable security requirements. Use it to build security requirements, verification checklists, and acceptance criteria.
+
+## Current version: ASVS 5.0.0 (May 2025)
+
+- ~350 requirements across **17 chapters**.
+- Each requirement has a stable ID: `v<version>-<chapter>.<section>.<requirement>`, e.g. `v5.0.0-6.2.3`.
+- Always include the version prefix when citing (`v5.0.0-...`) so the reference stays traceable across releases.
+
+## The 17 chapters (v5.0)
+
+| Ch | Focus |
+| --- | --- |
+| V1 | Encoding and Sanitization (injection prevention, safe deserialization, memory) |
+| V2 | Validation and Business Logic (input validation, anti-automation) |
+| V3 | Web Frontend Security (cookies, browser security headers, CSP, origin separation) |
+| V4 | API and Web Service (HTTP structure validation, GraphQL, WebSocket) |
+| V5 | File Handling (upload, storage, download) |
+| V6 | Authentication (password security, MFA, recovery, identity providers) |
+| V7 | Session Management (timeouts, termination, session abuse defenses) |
+| V8 | Authorization (object/function level, privilege escalation) |
+| V9 | Self-contained Tokens (JWT/source integrity, token content) |
+| V10 | OAuth and OIDC (clients, resource/auth servers, consent) |
+| V11 | Cryptography (algorithms, hashing, random values, key management) |
+| V12 | Secure Communication (TLS, service-to-service) |
+| V13 | Configuration (backend comm, secret management, info leakage) |
+| V14 | Data Protection (at rest, in transit, client-side) |
+| V15 | Secure Coding and Architecture (dependencies, defensive coding, concurrency) |
+| V16 | Security Logging and Error Handling (security events, log protection) |
+| V17 | WebRTC |
+
+## Three verification levels
+
+| Level | Purpose | Effort | Use case |
+| --- | --- | --- | --- |
+| L1 | Basic — minimum baseline, automatable | Dynamic/SAST, lightweight review | Marketing sites, internal tools, prototypes |
+| L2 | Standard — recommended default for apps with sensitive data | Automated + manual, code + docs review | Fintech, healthcare, SaaS with user data |
+| L3 | Advanced — highest assurance | Formal design review, threat modeling, deep manual testing | Banking, identity providers, gov/regulated systems |
+
+Each level is a **superset** of the previous: L3 implies full L1+L2 coverage.
+
+## How to use during an audit
+
+1. **Pick a level** based on the app's risk profile. Default to L2 for anything handling user data.
+2. **Derive requirements**: for each finding, identify the ASVS requirement(s) it violates and cite the ID (e.g. `v5.0.0-8.3.1` for a missing object-level authorization check).
+3. **Build a checklist**: when asked for security requirements or acceptance criteria, pull the relevant chapter's requirements and tailor to the app's architecture (skip chapters that don't apply, e.g. V17 WebRTC for a pure API).
+4. **Documented vs Implementation**: ASVS 5.0 separates *Documented Security Decisions* (architectural intent) from *Implementation Requirements* (testable behavior). Flag missing documentation as well as missing controls.
+5. **Map to Top 10**: each ASVS chapter maps to OWASP Top 10 categories — use the ASVS index of Cheat Sheets (`reference/owasp-cheat-sheets.md`) to find implementation guidance per requirement.
+
+## ASVS vs other frameworks
+- **ASVS** = what to verify (requirements for the app).
+- **OWASP SAMM** = how mature your security process is.
+- **Top 10** = what the broad risks are (awareness).
+- ASVS is the actionable, testable layer between awareness (Top 10) and process maturity (SAMM).
+
+## References
+- Project page — https://owasp.org/www-project-application-security-verification-standard/
+- ASVS 5.0.0 (GitHub) — https://github.com/OWASP/ASVS/tree/v5.0.0
+- Cheat Sheets indexed by ASVS section — https://cheatsheetseries.owasp.org/IndexASVS.html

--- a/skills/security-audit/reference/owasp-cheat-sheets.md
+++ b/skills/security-audit/reference/owasp-cheat-sheets.md
@@ -10,7 +10,7 @@ The Cheat Sheet Series gives concise, actionable implementation guidance for spe
 - **Credential Stuffing Prevention Cheat Sheet** — rate limiting, MFA, breach-password checks, CAPTCHA considerations.
 
 ### Tokens & sessions
-- **JSON Web Token Cheat Sheet** — when to use JWT, signing algorithms (RS256/ES256 over HS256), `alg: none` rejection, short expiry + refresh, claims validation (`exp`, `iss`, `aud`), storage in HttpOnly cookies not localStorage, key rotation.
+- **JSON Web Token Cheat Sheet** — when to use JWT, enforce an explicit algorithm allow-list (reject `alg: none` and unexpected algorithms), prefer asymmetric signing (RS256/ES256) when tokens are verified by multiple services, use short expiry + refresh, validate claims (`exp`, `iss`, `aud`), store in HttpOnly cookies (not localStorage), and rotate keys.
 - **Session Management Cheat Sheet** — session ID generation, rotation on auth, idle/absolute timeout, invalidation, secure cookie flags.
 
 ### Injection prevention
@@ -60,7 +60,7 @@ The Cheat Sheet Series gives concise, actionable implementation guidance for spe
 
 1. When a finding maps to a topic, cite the specific cheat sheet in the recommendation, e.g. *"Fix: follow the OWASP File Upload Cheat Sheet — validate magic bytes and store outside web root."*
 2. The cheat sheets are **indexed by ASVS section** (https://cheatsheetseries.owasp.org/IndexASVS.html) — use this to go from an ASVS requirement ID to the matching implementation guidance.
-3. Prefer the cheat sheet's concrete pattern over a vague recommendation. A finding that says "fix your JWT handling" is weak; one that says "switch HS256 to RS256, set short expiries with refresh tokens, store in HttpOnly cookies per the JWT Cheat Sheet" is actionable.
+3. Prefer the cheat sheet's concrete pattern over a vague recommendation. A finding that says "fix your JWT handling" is weak; one that says "enforce an explicit JWT algorithm allow-list, use asymmetric signing when multi-service verification is required, set short expiries with refresh tokens, and store tokens in HttpOnly cookies per the JWT Cheat Sheet" is actionable.
 
 ## References
 - Cheat Sheet Series home — https://cheatsheetseries.owasp.org/

--- a/skills/security-audit/reference/owasp-cheat-sheets.md
+++ b/skills/security-audit/reference/owasp-cheat-sheets.md
@@ -1,0 +1,68 @@
+# OWASP Cheat Sheet Series — Practical Implementation Guidance
+
+The Cheat Sheet Series gives concise, actionable implementation guidance for specific security topics. Use it when a finding needs a concrete fix pattern, not just a standard reference. Each cheat sheet is indexed to ASVS sections so requirements map to implementation.
+
+## Index by topic (most useful for audits)
+
+### Authentication & passwords
+- **Authentication Cheat Sheet** — general auth architecture, session vs token, step-up auth.
+- **Password Storage Cheat Sheet** — use bcrypt/argon2/scrypt; work factors; pepper vs salt; never MD5/SHA1.
+- **Credential Stuffing Prevention Cheat Sheet** — rate limiting, MFA, breach-password checks, CAPTCHA considerations.
+
+### Tokens & sessions
+- **JSON Web Token Cheat Sheet** — when to use JWT, signing algorithms (RS256/ES256 over HS256), `alg: none` rejection, short expiry + refresh, claims validation (`exp`, `iss`, `aud`), storage in HttpOnly cookies not localStorage, key rotation.
+- **Session Management Cheat Sheet** — session ID generation, rotation on auth, idle/absolute timeout, invalidation, secure cookie flags.
+
+### Injection prevention
+- **Injection Prevention Cheat Sheet** — parameterized queries, ORM safe usage, allow-list input validation, escaping by context.
+- **SQL Injection Prevention Cheat Sheet** — prepared statements, stored procedures done safely, escaping as last resort.
+- **Query Parameterization Cheat Sheet** — language/framework examples.
+- **OS Command Injection Cheat Sheet** — avoid shell with user input, use argument arrays, built-in safe APIs.
+
+### XSS & output encoding
+- **Cross-Site Scripting Prevention Cheat Sheet** — contextual output encoding, auto-escaping templates, CSP, `dangerouslySetInnerHTML`/`v-html` avoidance.
+- **DOM-based XSS Prevention Cheat Sheet** — safe sinks, `textContent` over `innerHTML`, sanitization with DOMPurify.
+- **XSS Filter Evasion Cheat Sheet** — know the bypasses to test defenses.
+
+### CSRF & request forgery
+- **Cross-Site Request Forgery Prevention Cheat Sheet** — token-based, SameSite cookie, double-submit, origin/header checks. Modern default: SameSite=Lax/Strict + origin validation.
+- **Server-Side Request Forgery Prevention Cheat Sheet** — URL allow-lists, block internal IP ranges, disable HTTP redirects, do not return raw responses.
+
+### File handling
+- **File Upload Cheat Sheet** — validate extension/MIME/content (magic bytes), rename on store, store outside web root, serve via proxy with `Content-Disposition`, scan for malware, size limits, disable script execution in upload dir.
+- **File Storage Cheat Sheet** — encryption at rest, access control, metadata handling.
+
+### Data protection & crypto
+- **Cryptographic Storage Cheat Sheet** — encryption at rest, key management, algorithm choice.
+- **Key Management Cheat Sheet** — generation, storage, rotation, separation of duties.
+- **Transport Layer Protection Cheat Sheet** — TLS config, HSTS, certificate pinning.
+
+### Access control
+- **Authorization Cheat Sheet** — deny by default, object-level checks, centralized authz, role/attribute models.
+- **Insecure Direct Object Reference Prevention Cheat Sheet** — indirect references, per-user mapping, ownership checks.
+- **Transaction Authorization Cheat Sheet** — step-up auth for high-value flows.
+
+### Configuration & infrastructure
+- **Clickjacking Defense Cheat Sheet** — `X-Frame-Options`, CSP `frame-ancestors`.
+- **Content Security Policy Cheat Sheet** — strict CSP, nonce-based, reporting.
+- **HTTP Strict Transport Security Cheat Sheet** — HSTS preload, includeSubDomains.
+- **XML External Entity Prevention Cheat Sheet** — disable DTD, external entities.
+- **Deserialization Cheat Sheet** — avoid untrusted deserialization, integrity checks, allow-list types.
+
+### Architecture & process
+- **Threat Modeling Cheat Sheet** — STRIDE, data flow, trust boundaries.
+- **Attack Surface Analysis Cheat Sheet** — reduce exposure, inventory endpoints.
+- **Abuse Case Cheat Sheet** — think like an attacker in requirements.
+- **Third-Party JavaScript Management Cheat Sheet** — SRI, subresource integrity, vendor review.
+- **Dependency Graph & SBOM Best Practices Cheat Sheet** — SBOM generation, transitive dep visibility.
+
+## How to use during an audit
+
+1. When a finding maps to a topic, cite the specific cheat sheet in the recommendation, e.g. *"Fix: follow the OWASP File Upload Cheat Sheet — validate magic bytes and store outside web root."*
+2. The cheat sheets are **indexed by ASVS section** (https://cheatsheetseries.owasp.org/IndexASVS.html) — use this to go from an ASVS requirement ID to the matching implementation guidance.
+3. Prefer the cheat sheet's concrete pattern over a vague recommendation. A finding that says "fix your JWT handling" is weak; one that says "switch HS256 to RS256, set short expiries with refresh tokens, store in HttpOnly cookies per the JWT Cheat Sheet" is actionable.
+
+## References
+- Cheat Sheet Series home — https://cheatsheetseries.owasp.org/
+- ASVS-indexed cheat sheets — https://cheatsheetseries.owasp.org/IndexASVS.html
+- GitHub repo — https://github.com/OWASP/CheatSheetSeries

--- a/skills/security-audit/reference/owasp-top-10.md
+++ b/skills/security-audit/reference/owasp-top-10.md
@@ -1,0 +1,51 @@
+# OWASP Top 10 — Vulnerability Categories
+
+The OWASP Top 10 is the standard awareness document for the most critical web application security risks. Two editions are in active use: **2021** (widely referenced in tooling and compliance) and **2025** (the latest release). Cite which edition you are mapping to.
+
+## OWASP Top 10:2025 (latest)
+
+| ID | Category | Focus |
+| --- | --- | --- |
+| A01:2025 | Broken Access Control | Still #1. Authorization failures, IDOR, privilege escalation. |
+| A02:2025 | Security Misconfiguration | Moved up. Configuration errors, default creds, verbose errors, IaC misconfig. |
+| A03:2025 | Software Supply Chain Failures | **New #3.** Expands beyond dependencies to build tools, pipelines, containers, package registries. |
+| A04:2025 | Cryptographic Failures | Weak/broken crypto, plaintext transport, key management. |
+| A05:2025 | Injection | SQLi, NoSQLi, XSS (now folded in), command injection, LDAP injection. |
+| A06:2025 | Insecure Design | Missing threat modeling, no abuse cases, design-level flaws. |
+| A07:2025 | Authentication Failures | Credential stuffing, weak recovery, session management, MFA gaps. |
+| A08:2025 | Software or Data Integrity Failures | Unsigned updates, unsafe deserialization, CI/CD integrity. |
+| A09:2025 | Security Logging and Alerting Failures | Missing detection, no alerting on security events. |
+| A10:2025 | Mishandling of Exceptional Conditions | **New.** Improper error handling, failing open, NULL deref, unhandled edge cases. |
+
+### Key 2021 → 2025 shifts
+- **A03** renamed from *Vulnerable and Outdated Components* to *Software Supply Chain Failures* — the supply chain is now treated as part of the application.
+- **A10** is brand new: *Mishandling of Exceptional Conditions* (24 CWEs covering fail-open, NULL deref, missing-param handling, sensitive info in errors).
+- *Server-Side Request Forgery* (A10:2021) is folded into broader categories.
+- Order shifted: Misconfiguration rose to #2, Injection dropped to #5.
+
+## OWASP Top 10:2021 (still widely referenced)
+
+| ID | Category |
+| --- | --- |
+| A01:2021 | Broken Access Control |
+| A02:2021 | Cryptographic Failures (was "Sensitive Data Exposure") |
+| A03:2021 | Injection (XSS folded in) |
+| A04:2021 | Insecure Design (new) |
+| A05:2021 | Security Misconfiguration (XXE folded in) |
+| A06:2021 | Vulnerable and Outdated Components |
+| A07:2021 | Identification and Authentication Failures |
+| A08:2021 | Software and Data Integrity Failures (new; deserialization folded in) |
+| A09:2021 | Security Logging and Monitoring Failures |
+| A10:2021 | Server-Side Request Forgery (SSRF) (new) |
+
+## How to use during an audit
+
+1. For each finding, identify the **root cause category**, not just the symptom. OWASP 2021+ intentionally names categories by root cause (e.g. "Cryptographic Failures" not "Sensitive Data Exposure").
+2. Map the finding to the CWE(s) under the category when possible — this aids tool correlation and remediation tracking.
+3. State the edition: `A03:2021-Injection` vs `A05:2025-Injection` — the numbering changed.
+4. Check the 2025 list for findings that fit the new categories (supply chain, exceptional conditions) even if you also reference 2021.
+
+## References
+- OWASP Top 10:2025 — https://owasp.org/Top10/2025/
+- OWASP Top 10:2021 — https://owasp.org/Top10/2021/
+- Main project page — https://owasp.org/www-project-top-ten/

--- a/skills/security-audit/reference/owasp-top-10.md
+++ b/skills/security-audit/reference/owasp-top-10.md
@@ -20,7 +20,7 @@ The OWASP Top 10 is the standard awareness document for the most critical web ap
 ### Key 2021 → 2025 shifts
 - **A03** renamed from *Vulnerable and Outdated Components* to *Software Supply Chain Failures* — the supply chain is now treated as part of the application.
 - **A10** is brand new: *Mishandling of Exceptional Conditions* (24 CWEs covering fail-open, NULL deref, missing-param handling, sensitive info in errors).
-- *Server-Side Request Forgery* (A10:2021) is folded into broader categories.
+- *Server-Side Request Forgery* (A10:2021) is folded into broader categories in 2025, most commonly **A01:2025 Broken Access Control** when internal resources are reachable because authorization/trust boundaries fail.
 - Order shifted: Misconfiguration rose to #2, Injection dropped to #5.
 
 ## OWASP Top 10:2021 (still widely referenced)


### PR DESCRIPTION
## What

Add a comprehensive canonical `skills/security-audit/` skill covering the five core security knowledge areas:

1. **OWASP Top 10** — both the 2021 and 2025 editions, with the category shifts (new A03 Software Supply Chain Failures, new A10 Mishandling of Exceptional Conditions).
2. **OWASP ASVS (Application Security Verification Standard)** — ASVS 5.0.0: 17 chapters, 3 verification levels, stable requirement IDs (`v5.0.0-x.y.z`).
3. **OWASP Cheat Sheet Series** — practical implementation guidance for authentication, JWT, file uploads, password storage, CSRF, injection prevention, and more, indexed by ASVS section.
4. **Node.js Security Best Practices** — Express, NestJS, and Fastify framework-specific hardening plus dependency/supply-chain management (prototype pollution, ReDoS, `npm ci`, lockfiles, EOL runtimes, non-root containers).
5. **DevSecOps** — integrating SAST, DAST, dependency scanning, container scanning, secret detection, and IaC scanning into CI/CD with security gates.

The skill uses **progressive disclosure**: `SKILL.md` holds the audit process, an OWASP-mapped checklist, severity ranking, and output format (~184 lines). Detailed per-topic guidance lives in five `reference/` files loaded on demand so context cost stays low unless a finding maps to that area.

Files added:
- `skills/security-audit/SKILL.md`
- `skills/security-audit/reference/owasp-top-10.md`
- `skills/security-audit/reference/owasp-asvs.md`
- `skills/security-audit/reference/owasp-cheat-sheets.md`
- `skills/security-audit/reference/nodejs-security.md`
- `skills/security-audit/reference/devsecops.md`

## Why

The existing `security-audit` skill was a one-line checklist duplicated across tool-specific config directories (`configs/amp/skills/`, `configs/cline/skills/`, `configs/kimi-code/skills/`) with no grounding in security standards. There was no canonical universal skill in `skills/` (the directory installed to `~/.agents/skills/` and symlinked to every tool).

This upgrade gives every supported AI coding assistant (Claude, OpenCode, Amp, Codex, Gemini, Cursor, Pi, Cline, etc.) a single, comprehensive, standards-backed security audit skill that:
- Classifies findings against OWASP Top 10 categories (citing the edition).
- Derives concrete, testable requirements from ASVS with traceable IDs.
- Recommends fixes using the OWASP Cheat Sheet Series patterns.
- Checks Node.js framework-specific concerns (Express/NestJS/Fastify) and supply-chain hygiene.
- Verifies CI/CD security controls (dependency/secret/container/SAST/DAST scanning and gates).

## How

- **Canonical universal skill**: created `skills/security-audit/` so `install_local_skills` installs it to `~/.agents/skills/` and symlinks it into every tool-specific skills directory (`~/.config/amp/skills`, `~/.claude/skills`, etc.). The `copy_amp_configs` installer does not copy `configs/amp/skills/`, confirming the universal path is the one that ships.
- **Progressive disclosure**: kept `SKILL.md` under 200 lines with a knowledge-base table that tells the agent which `reference/` file to load for each topic. This follows the building-skills convention (SKILL.md < 500 lines; split large content into `reference/`).
- **Standards traceability**: every finding's recommendation cites the OWASP Top 10 category, the ASVS requirement ID (e.g. `v5.0.0-8.3.1`), and the relevant Cheat Sheet — so output is auditable and educational, not just descriptive.
- **Frontmatter**: matches the repo convention (`compatibility: cline, claude, opencode, amp, codex, gemini, cursor, pi`; `user-invocable: true`; `metadata.workflow: security`).

Research sources: OWASP Top 10:2025 (https://owasp.org/Top10/2025/), ASVS 5.0.0 (https://github.com/OWASP/ASVS/tree/v5.0.0), Cheat Sheet Series (https://cheatsheetseries.owasp.org/), Node.js security docs (https://nodejs.org/learn/getting-started/security-best-practices), Express/NestJS/Fastify docs, and DevSecOps tooling docs (Trivy, Semgrep, Gitleaks, TruffleHog, OWASP ZAP).

## Verification

- `bash -n cli.sh generate.sh lib/*.sh` — shell syntax OK.
- `./cli.sh --dry-run` — completes cleanly (only pre-existing tool-availability warnings).
- `bats tests/recommend_skills.bats` — all 52 tests pass.
- `bats tests/sh_reexec.bats` — all 10 tests pass.
- Throwaway-`HOME` install test (`install_local_skills`): `security-audit` lands in `~/.agents/skills/` with `SKILL.md` + all 5 `reference/` files, and symlinks correctly to `~/.config/amp/skills`, `~/.claude/skills`, `~/.codex/skills`, etc.
- `biome check` — the `skills/` tree is markdown-only and not in biome's scope (no formatting change).

## Checklist

- [x] Tests added or updated (existing tests pass; no new test file needed — skill is documentation)
- [x] Documentation updated (the skill *is* documentation)
- [x] No breaking changes (additive only — no existing file modified)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only security auditing workflow with repository inspection, scope selection, checklists, severity classification, and standardized reporting.
  - Added guidance for Node.js, Express, NestJS, Fastify, dependency security, and supply-chain risks.
  - Added DevSecOps recommendations for CI/CD security checks, scanning, security gates, SBOMs, and pipeline hardening.
  - Added references covering OWASP ASVS, OWASP Top 10, and OWASP Cheat Sheets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->