### PR TITLE
feat: add Hunk tool support

### DIFF
--- a/.changeset/add-hunk-support.md
+++ b/.changeset/add-hunk-support.md
@@ -1,0 +1,6 @@
+---
+"my-ai-tools": minor
+---
+
+Add Hunk as a supported terminal diff reviewer with installation, configuration,
+backup, and bidirectional sync support.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub license](https://img.shields.io/github/license/jellydn/my-ai-tools)](https://github.com/jellydn/my-ai-tools/blob/main/LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/jellydn/my-ai-tools/pulls)
 
-> **Comprehensive configuration management for AI coding tools** - Replicate my complete setup for Claude Code, OpenCode, Amp, Kilo CLI, Codex, Devin CLI, Kimi Code, Gemini CLI, Antigravity CLI, Pi, Oh My Pi, GitHub Copilot CLI, Cursor Agent CLI, Factory Droid, Cline, Grok CLI, MiMo-Code, Qoder CLI, Kiro CLI, Codiff, ctx, Open Code Review, CCS, and Reasonix with custom configurations, MCP servers, skills, plugins, and commands.
+> **Comprehensive configuration management for AI coding tools** - Replicate my complete setup for Claude Code, OpenCode, Amp, Kilo CLI, Codex, Devin CLI, Kimi Code, Gemini CLI, Antigravity CLI, Pi, Oh My Pi, GitHub Copilot CLI, Cursor Agent CLI, Factory Droid, Cline, Grok CLI, MiMo-Code, Qoder CLI, Kiro CLI, Hunk, Codiff, ctx, Open Code Review, CCS, and Reasonix with custom configurations, MCP servers, skills, plugins, and commands.
 
 📖 **[View Documentation Website](https://ai-tools.itman.fyi)** - Interactive landing page with full documentation and search.
 
@@ -12,7 +12,7 @@
 
 - 🚀 **One-line installer** - Get started in seconds
 - 🔄 **Bidirectional sync** - Install configs or export your current setup
-- 🤖 **Multiple AI tools** - Claude Code, OpenCode, Amp, CCS, Devin, Kimi Code, Gemini, Antigravity, Grok, MiMo-Code, Qoder CLI, Kiro CLI, Codiff, ctx, Open Code Review, Reasonix, and more
+- 🤖 **Multiple AI tools** - Claude Code, OpenCode, Amp, CCS, Devin, Kimi Code, Gemini, Antigravity, Grok, MiMo-Code, Qoder CLI, Kiro CLI, Hunk, Codiff, ctx, Open Code Review, Reasonix, and more
 - 🔌 **MCP Server integration** - Context7, Sequential-thinking, qmd, codebase-memory-mcp, agentmemory, sem, ctx
 - 🎯 **Custom agents & skills** - Pre-configured for maximum productivity
 - 🤝 **Agent Teams** - Coordinate specialized agents for complex workflows (code review, testing, docs)
@@ -2982,6 +2982,56 @@ kiro /usage
 See the full [Kiro CLI docs](https://kiro.dev/docs/cli/installation/) for details.
 
 ## </details>
+
+## 🔍 Hunk (Optional)
+
+Review-first terminal diff viewer for agent-authored changesets, with multi-file navigation, inline agent notes, watch mode, and Git, Jujutsu, and Sapling support. [Homepage](https://www.hunk.dev/) | [Docs](https://www.hunk.dev/docs/) | [GitHub](https://github.com/modem-dev/hunk)
+
+<details>
+<summary><strong>Installation &amp; Configuration</strong></summary>
+
+### Installation
+
+```bash
+# Cross-platform (Node.js 18+)
+npm install --global hunkdiff
+
+# macOS (Homebrew core)
+brew install hunk
+```
+
+Or run this repo's installer:
+
+```bash
+./cli.sh
+```
+
+### Configuration
+
+The checked-in [`configs/hunk/config.toml`](configs/hunk/config.toml) is installed to `$XDG_CONFIG_HOME/hunk/config.toml`, or `~/.config/hunk/config.toml` when `XDG_CONFIG_HOME` is unset. It selects Hunk's built-in Kanagawa Wave theme and shows agent notes when a review opens.
+
+Repository-specific settings can override the user config in `.hunk/config.toml`. CLI flags have the highest precedence. This integration does not change the global Git pager; opt in separately if desired:
+
+```bash
+git config --global core.pager "hunk pager"
+```
+
+### Usage
+
+```bash
+hunk diff          # Review the working tree, including untracked files
+hunk diff --watch  # Reload as an agent changes the working tree
+hunk show          # Review the latest commit
+hunk session list  # List live review sessions for agent interaction
+```
+
+The recommended [Hunk Review skill](https://github.com/modem-dev/hunk/blob/main/skills/hunk-review/SKILL.md) teaches coding agents to inspect live sessions and add inline comments without launching the interactive TUI themselves.
+
+See the official [install guide](https://www.hunk.dev/docs/start/install/) and [config reference](https://www.hunk.dev/docs/reference/config) for all platforms and preferences.
+
+</details>
+
+---
 
 ## 🎨 Codiff (Optional)
 

--- a/cli.sh
+++ b/cli.sh
@@ -53,6 +53,7 @@ INSTALL_SEQUENCE=(
 	"conductor:install_conductor"
 	"herdr:install_herdr"
 	"ctx:install_ctx"
+	"hunk:install_hunk"
 	"qodercli:install_qodercli"
 	"kiro:install_kiro"
 	"codiff:install_codiff"
@@ -349,6 +350,7 @@ backup_configs() {
 		copy_config_dir "$HOME/.codiff" "$BACKUP_DIR" "codiff"
 		copy_config_dir "$HOME/.config/devin" "$BACKUP_DIR" "devin"
 		copy_config_dir "$HOME/.ctx" "$BACKUP_DIR" "ctx"
+		copy_config_dir "${XDG_CONFIG_HOME:-$HOME/.config}/hunk" "$BACKUP_DIR" "hunk"
 		copy_config_file "$HOME/.config/ai-launcher/config.json" "$BACKUP_DIR/ai-launcher" || true
 
 		log_success "Backup completed: $BACKUP_DIR"
@@ -576,6 +578,11 @@ copy_configurations() {
 	else
 		log_info "Skipping ctx config install (not in -y allowlist)"
 	fi
+	if tool_allowed "hunk"; then
+		copy_hunk_configs
+	else
+		log_info "Skipping hunk config install (not in -y allowlist)"
+	fi
 	if tool_allowed "qodercli"; then
 		copy_qodercli_configs
 	else
@@ -636,6 +643,7 @@ _validate_config_tool_name() {
 		*antigravity-cli/settings.json*) echo "antigravity" ;;
 		*kilo/config.json*) echo "kilo" ;;
 		*reasonix/config.toml*) echo "reasonix" ;;
+		*hunk/config.toml*) echo "hunk" ;;
 		*kimi-code/*.json* | *kimi-code/*.toml*) echo "kimi_code" ;;
 		*pi/settings.json*) echo "pi" ;;
 		*omp/*.yml* | *omp/*.yaml* | *omp/*.json*) echo "omp" ;;
@@ -681,6 +689,7 @@ validate_all_configs() {
 		"$SCRIPT_DIR/configs/antigravity-cli/settings.json" \
 		"$SCRIPT_DIR/configs/kilo/config.json" \
 		"$SCRIPT_DIR/configs/reasonix/config.toml" \
+		"$SCRIPT_DIR/configs/hunk/config.toml" \
 		"$SCRIPT_DIR/configs/kimi-code/config.toml" \
 		"$SCRIPT_DIR/configs/kimi-code/mcp.json" \
 		"$SCRIPT_DIR/configs/pi/settings.json" \
@@ -1768,6 +1777,23 @@ copy_ctx_configs() {
 	log_success "ctx configs copied"
 }
 
+copy_hunk_configs() {
+	local hunk_status
+	local hunk_dir="${XDG_CONFIG_HOME:-$HOME/.config}/hunk"
+	hunk_status=$(detect_tool --detailed "hunk" "$hunk_dir") || hunk_status="missing"
+	if [ "$hunk_status" = "missing" ]; then
+		log_info "Hunk not detected - skipping Hunk config installation"
+		return 0
+	fi
+
+	log_info "Detected Hunk (via $hunk_status)"
+	execute_quoted mkdir -p "$hunk_dir"
+
+	copy_config_file "$SCRIPT_DIR/configs/hunk/config.toml" "$hunk_dir/" || true
+
+	log_success "Hunk configs copied"
+}
+
 copy_qodercli_configs() {
 	local qodercli_status
 	qodercli_status=$(detect_tool --detailed "qodercli" "$HOME/.qoder") || qodercli_status="missing"
@@ -2628,7 +2654,7 @@ main() {
 	echo "║  Claude • OpenCode • Amp • CCS • Codex • Kimi Code • Gemini          ║"
 	echo "║  Antigravity • Pi • Kilo • Copilot • Cursor • Command Code           ║"
 	echo "║  Factory Droid • Cline • Grok • MiMo-Code • herdr                    ║"
-	echo "║  Qoder CLI • Kiro • Codiff • Devin                                   ║"
+	echo "║  Qoder CLI • Kiro • Codiff • Devin • Hunk                            ║"
 	echo "║  ctx • Reasonix                                                       ║"
 	echo "╚══════════════════════════════════════════════════════════════════════╝"
 	echo

--- a/cli.sh
+++ b/cli.sh
@@ -1787,9 +1787,12 @@ copy_hunk_configs() {
 	fi
 
 	log_info "Detected Hunk (via $hunk_status)"
-	execute_quoted mkdir -p "$hunk_dir"
+	execute_quoted mkdir -p "$hunk_dir" || return 1
 
-	copy_config_file "$SCRIPT_DIR/configs/hunk/config.toml" "$hunk_dir/" || true
+	if ! copy_config_file "$SCRIPT_DIR/configs/hunk/config.toml" "$hunk_dir/"; then
+		log_error "Failed to copy Hunk config to $hunk_dir"
+		return 1
+	fi
 
 	log_success "Hunk configs copied"
 }

--- a/configs/hunk/config.toml
+++ b/configs/hunk/config.toml
@@ -1,0 +1,15 @@
+theme = "kanagawa-wave"
+mode = "auto"
+cursor_line = "row"
+vcs = "git"
+watch = false
+exclude_untracked = false
+line_numbers = true
+tab_width = 4
+wrap_lines = false
+hunk_headers = true
+menu_bar = true
+agent_notes = true
+copy_decorations = false
+prompt_save_view_preferences = true
+transparent_background = false

--- a/generate.sh
+++ b/generate.sh
@@ -842,6 +842,22 @@ generate_ctx_configs() {
 	log_success "ctx configs generated"
 }
 
+generate_hunk_configs() {
+	log_info "Generating Hunk configs..."
+	local hunk_dir="${XDG_CONFIG_HOME:-$HOME/.config}/hunk"
+
+	if [ ! -d "$hunk_dir" ]; then
+		log_warning "Hunk config directory not found: $hunk_dir"
+		return 0
+	fi
+
+	execute "mkdir -p \"$SCRIPT_DIR/configs/hunk\""
+
+	copy_single "$hunk_dir/config.toml" "$SCRIPT_DIR/configs/hunk/config.toml"
+
+	log_success "Hunk configs generated"
+}
+
 generate_qodercli_configs() {
 	log_info "Generating Qoder CLI configs..."
 
@@ -1156,6 +1172,9 @@ main() {
 	echo
 
 	generate_ctx_configs
+	echo
+
+	generate_hunk_configs
 	echo
 
 	generate_qodercli_configs

--- a/generate.sh
+++ b/generate.sh
@@ -851,6 +851,11 @@ generate_hunk_configs() {
 		return 0
 	fi
 
+	if [ ! -f "$hunk_dir/config.toml" ]; then
+		log_warning "Hunk config not found: $hunk_dir/config.toml"
+		return 0
+	fi
+
 	execute "mkdir -p \"$SCRIPT_DIR/configs/hunk\""
 
 	copy_single "$hunk_dir/config.toml" "$SCRIPT_DIR/configs/hunk/config.toml"

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -628,8 +628,43 @@ install_open_code_review() {
 }
 
 install_hunk() {
-	install_npm_tool "Hunk" "hunk" "hunkdiff" \
-		"npm install --global hunkdiff"
+	_run_hunk_install() {
+		if ! command -v node &>/dev/null; then
+			log_error "Hunk's npm package requires Node.js 18 or newer."
+			log_info "Install Node.js 18+ or install Hunk through Homebrew or mise."
+			return 1
+		fi
+
+		local node_major
+		node_major=$(node -p 'process.versions.node.split(".")[0]' 2>/dev/null) || node_major=""
+		if ! [[ "$node_major" =~ ^[0-9]+$ ]] || [ "$node_major" -lt 18 ]; then
+			log_error "Hunk requires Node.js 18 or newer (found: $(node --version 2>/dev/null || echo unknown))."
+			return 1
+		fi
+
+		local pkg_manager
+		pkg_manager=$(_verify_package_manager "Hunk")
+		if [ -z "$pkg_manager" ]; then
+			log_error "No package manager found. Install npm or Bun to install Hunk."
+			return 1
+		fi
+
+		log_info "Installing Hunk with $pkg_manager..."
+		if ! execute "$pkg_manager install -g hunkdiff"; then
+			log_error "Failed to install Hunk"
+			log_info "You can install it manually: npm install --global hunkdiff"
+			return 1
+		fi
+
+		if ! execute "hunk --version >/dev/null"; then
+			log_error "Hunk was installed but could not start."
+			return 1
+		fi
+
+		log_success "Hunk installed and verified"
+	}
+
+	run_installer "Hunk" "_run_hunk_install" "command -v hunk && hunk --version" "hunk --version"
 }
 
 install_conductor() {

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -627,6 +627,11 @@ install_open_code_review() {
 		"npm install -g @alibaba-group/open-code-review"
 }
 
+install_hunk() {
+	install_npm_tool "Hunk" "hunk" "hunkdiff" \
+		"npm install --global hunkdiff"
+}
+
 install_conductor() {
 	if [ -d "/Applications/Conductor.app" ]; then
 		log_success "Conductor is already installed"

--- a/tests/pr_hunk.bats
+++ b/tests/pr_hunk.bats
@@ -23,10 +23,43 @@ README="$REPO_ROOT/README.md"
 }
 
 @test "Hunk uses the official hunkdiff npm package" {
-	run grep -F 'install_npm_tool "Hunk" "hunk" "hunkdiff"' "$LIB_INSTALL"
+	run grep -F 'install -g hunkdiff' "$LIB_INSTALL"
 	[ "$status" -eq 0 ]
 	run grep -F '"hunk:install_hunk"' "$CLI_SH"
 	[ "$status" -eq 0 ]
+}
+
+@test "Hunk installer rejects Node.js older than 18" {
+	run bash -c '
+		export DRY_RUN=false YES_TO_ALL=true IS_WINDOWS=false VERBOSE=false
+		source "$1/lib/common.sh"
+		source "$1/lib/install.sh"
+		node() {
+			if [ "$1" = "-p" ]; then
+				echo 17
+			else
+				echo v17.9.1
+			fi
+		}
+		install_hunk
+	' _ "$REPO_ROOT"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"requires Node.js 18 or newer"* ]]
+}
+
+@test "Hunk installer fails when the installed binary cannot start" {
+	run bash -c '
+		export DRY_RUN=false YES_TO_ALL=true IS_WINDOWS=false VERBOSE=false
+		source "$1/lib/common.sh"
+		source "$1/lib/install.sh"
+		_verify_package_manager() { echo npm; }
+		execute() {
+			[ "$1" != "hunk --version >/dev/null" ]
+		}
+		install_hunk
+	' _ "$REPO_ROOT"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"installed but could not start"* ]]
 }
 
 @test "Hunk config install honors XDG_CONFIG_HOME" {
@@ -45,13 +78,68 @@ README="$REPO_ROOT/README.md"
 	[ "$status" -eq 0 ]
 }
 
-@test "Hunk config is backed up and reverse-synced" {
+@test "Hunk config copy failures are reported" {
+	run bash -c '
+		temp_home=$(mktemp -d)
+		trap '\''rm -rf "$temp_home"'\'' EXIT
+		export HOME="$temp_home" XDG_CONFIG_HOME="$temp_home/xdg"
+		export DRY_RUN=false YES_TO_ALL=false VERBOSE=false
+		mkdir -p "$XDG_CONFIG_HOME/hunk"
+		source "$1/cli.sh"
+		copy_config_file() { return 1; }
+		copy_hunk_configs
+	' _ "$REPO_ROOT"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Failed to copy Hunk config"* ]]
+	[[ "$output" != *"Hunk configs copied"* ]]
+}
+
+@test "Hunk config is backed up and reverse-synced at runtime" {
 	run grep -F '${XDG_CONFIG_HOME:-$HOME/.config}/hunk' "$CLI_SH"
 	[ "$status" -eq 0 ]
 	run grep -F 'generate_hunk_configs' "$GENERATE_SH"
 	[ "$status" -eq 0 ]
-	run grep -F 'copy_single "$hunk_dir/config.toml" "$SCRIPT_DIR/configs/hunk/config.toml"' "$GENERATE_SH"
+
+	run bash -c '
+		set -e
+		temp_home=$(mktemp -d)
+		temp_repo=$(mktemp -d)
+		trap '\''rm -rf "$temp_home" "$temp_repo"'\'' EXIT
+		export HOME="$temp_home" XDG_CONFIG_HOME="$temp_home/xdg"
+		export DRY_RUN=false YES_TO_ALL=false VERBOSE=false
+		mkdir -p "$XDG_CONFIG_HOME/hunk"
+		cp "$1/configs/hunk/config.toml" "$XDG_CONFIG_HOME/hunk/config.toml"
+
+		source "$1/cli.sh"
+		BACKUP=true
+		PROMPT_BACKUP=false
+		BACKUP_DIR="$temp_home/backup"
+		backup_configs >/dev/null
+		cmp "$1/configs/hunk/config.toml" "$BACKUP_DIR/hunk/config.toml"
+
+		source "$1/generate.sh"
+		SCRIPT_DIR="$temp_repo"
+		generate_hunk_configs >/dev/null
+		cmp "$1/configs/hunk/config.toml" "$temp_repo/configs/hunk/config.toml"
+	' _ "$REPO_ROOT"
 	[ "$status" -eq 0 ]
+}
+
+@test "Hunk export does not report success without config.toml" {
+	run bash -c '
+		temp_home=$(mktemp -d)
+		temp_repo=$(mktemp -d)
+		trap '\''rm -rf "$temp_home" "$temp_repo"'\'' EXIT
+		export HOME="$temp_home" XDG_CONFIG_HOME="$temp_home/xdg"
+		export DRY_RUN=false VERBOSE=false
+		mkdir -p "$XDG_CONFIG_HOME/hunk"
+		source "$1/generate.sh"
+		SCRIPT_DIR="$temp_repo"
+		generate_hunk_configs
+	' _ "$REPO_ROOT"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Hunk config not found"* ]]
+	[[ "$output" != *"Hunk configs generated"* ]]
 }
 
 @test "README documents Hunk installation, config, and review usage" {

--- a/tests/pr_hunk.bats
+++ b/tests/pr_hunk.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+# Tests for Hunk integration
+
+load helpers
+
+LIB_INSTALL="$REPO_ROOT/lib/install.sh"
+CLI_SH="$REPO_ROOT/cli.sh"
+GENERATE_SH="$REPO_ROOT/generate.sh"
+CONFIG="$REPO_ROOT/configs/hunk/config.toml"
+README="$REPO_ROOT/README.md"
+
+@test "Hunk config exists and is valid TOML" {
+	[ -f "$CONFIG" ]
+	run bash -c 'source "$1/lib/common.sh"; validate_config "$1/configs/hunk/config.toml"' _ "$REPO_ROOT"
+	[ "$status" -eq 0 ]
+}
+
+@test "Hunk config enables the built-in Kanagawa theme and agent notes" {
+	run grep -F 'theme = "kanagawa-wave"' "$CONFIG"
+	[ "$status" -eq 0 ]
+	run grep -F 'agent_notes = true' "$CONFIG"
+	[ "$status" -eq 0 ]
+}
+
+@test "Hunk uses the official hunkdiff npm package" {
+	run grep -F 'install_npm_tool "Hunk" "hunk" "hunkdiff"' "$LIB_INSTALL"
+	[ "$status" -eq 0 ]
+	run grep -F '"hunk:install_hunk"' "$CLI_SH"
+	[ "$status" -eq 0 ]
+}
+
+@test "Hunk config install honors XDG_CONFIG_HOME" {
+	run bash -c '
+		set -e
+		temp_home=$(mktemp -d)
+		temp_xdg=$(mktemp -d)
+		trap '\''rm -rf "$temp_home" "$temp_xdg"'\'' EXIT
+		export HOME="$temp_home" XDG_CONFIG_HOME="$temp_xdg"
+		export DRY_RUN=false YES_TO_ALL=false VERBOSE=false
+		mkdir -p "$XDG_CONFIG_HOME/hunk"
+		source "$1/cli.sh"
+		copy_hunk_configs >/dev/null
+		cmp "$1/configs/hunk/config.toml" "$XDG_CONFIG_HOME/hunk/config.toml"
+	' _ "$REPO_ROOT"
+	[ "$status" -eq 0 ]
+}
+
+@test "Hunk config is backed up and reverse-synced" {
+	run grep -F '${XDG_CONFIG_HOME:-$HOME/.config}/hunk' "$CLI_SH"
+	[ "$status" -eq 0 ]
+	run grep -F 'generate_hunk_configs' "$GENERATE_SH"
+	[ "$status" -eq 0 ]
+	run grep -F 'copy_single "$hunk_dir/config.toml" "$SCRIPT_DIR/configs/hunk/config.toml"' "$GENERATE_SH"
+	[ "$status" -eq 0 ]
+}
+
+@test "README documents Hunk installation, config, and review usage" {
+	run grep -F 'npm install --global hunkdiff' "$README"
+	[ "$status" -eq 0 ]
+	run grep -F 'configs/hunk/config.toml' "$README"
+	[ "$status" -eq 0 ]
+	run grep -F 'hunk diff --watch' "$README"
+	[ "$status" -eq 0 ]
+	run grep -F 'https://www.hunk.dev/docs/reference/config' "$README"
+	[ "$status" -eq 0 ]
+}
+
+@test "Hunk support has a changeset" {
+	[ -f "$REPO_ROOT/.changeset/add-hunk-support.md" ]
+}

--- a/tests/pr_hunk.bats
+++ b/tests/pr_hunk.bats
@@ -52,6 +52,13 @@ README="$REPO_ROOT/README.md"
 		export DRY_RUN=false YES_TO_ALL=true IS_WINDOWS=false VERBOSE=false
 		source "$1/lib/common.sh"
 		source "$1/lib/install.sh"
+		node() {
+			if [ "$1" = "-p" ]; then
+				echo 18
+			else
+				echo v18.0.0
+			fi
+		}
 		_verify_package_manager() { echo npm; }
 		execute() {
 			[ "$1" != "hunk --version >/dev/null" ]


### PR DESCRIPTION
## Summary

- install Hunk from the official `hunkdiff` npm package and register it as a supported tool
- add XDG-aware config installation, backup, validation, and bidirectional export
- provide a Kanagawa Wave configuration with agent notes enabled
- document installation, configuration precedence, usage, and optional Git pager setup
- add focused Bats coverage and a minor changeset

## Validation

- `bats tests/pr_*.bats tests/generate.bats tests/sh_reexec.bats` — 392/392 passed
- `./cli.sh --dry-run --yes` — passed
- `./generate.sh --dry-run` — passed
- isolated `install_hunk` dry-run — passed
- `bash -n cli.sh generate.sh install.sh lib/*.sh scripts/*.sh` — passed
- `git diff --check` and `git show --check` — passed

## Notes

No authentication is required for Hunk. Global Git pager integration remains opt-in and is not changed by the installer.

`biome check .` continues to report the repository's existing unrelated TypeScript formatting deviations; the added Markdown, Bats, and TOML files are ignored by the current Biome configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Hunk as a terminal diff reviewer.
  * Added installation, configuration, backup, and bidirectional synchronization support.
  * Added Git pager integration, review commands, watch mode, session management, and Hunk Review guidance.
  * Added a preconfigured Hunk setup with Kanagawa Wave styling and agent notes.

* **Documentation**
  * Updated the README with Hunk installation, configuration, and usage instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->