### PR TITLE
feat: add fx coding agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub license](https://img.shields.io/github/license/jellydn/my-ai-tools)](https://github.com/jellydn/my-ai-tools/blob/main/LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/jellydn/my-ai-tools/pulls)
 
-> **Comprehensive configuration management for AI coding tools** - Replicate my complete setup for Claude Code, OpenCode, Amp, Kilo CLI, Codex, Devin CLI, Kimi Code, Gemini CLI, Antigravity CLI, Pi, Oh My Pi, GitHub Copilot CLI, Cursor Agent CLI, Factory Droid, Cline, Grok CLI, MiMo-Code, Qoder CLI, Kiro CLI, Hunk, Codiff, ctx, Open Code Review, CCS, and Reasonix with custom configurations, MCP servers, skills, plugins, and commands.
+> **Comprehensive configuration management for AI coding tools** - Replicate my complete setup for Claude Code, OpenCode, fx, Amp, Kilo CLI, Codex, Devin CLI, Kimi Code, Gemini CLI, Antigravity CLI, Pi, Oh My Pi, GitHub Copilot CLI, Cursor Agent CLI, Factory Droid, Cline, Grok CLI, MiMo-Code, Qoder CLI, Kiro CLI, Hunk, Codiff, ctx, Open Code Review, CCS, and Reasonix with custom configurations, MCP servers, skills, plugins, and commands.
 
 📖 **[View Documentation Website](https://ai-tools.itman.fyi)** - Interactive landing page with full documentation and search.
 
@@ -12,7 +12,7 @@
 
 - 🚀 **One-line installer** - Get started in seconds
 - 🔄 **Bidirectional sync** - Install configs or export your current setup
-- 🤖 **Multiple AI tools** - Claude Code, OpenCode, Amp, CCS, Devin, Kimi Code, Gemini, Antigravity, Grok, MiMo-Code, Qoder CLI, Kiro CLI, Hunk, Codiff, ctx, Open Code Review, Reasonix, and more
+- 🤖 **Multiple AI tools** - Claude Code, OpenCode, fx, Amp, CCS, Devin, Kimi Code, Gemini, Antigravity, Grok, MiMo-Code, Qoder CLI, Kiro CLI, Hunk, Codiff, ctx, Open Code Review, Reasonix, and more
 - 🔌 **MCP Server integration** - Context7, Sequential-thinking, qmd, codebase-memory-mcp, agentmemory, sem, ctx
 - 🎯 **Custom agents & skills** - Pre-configured for maximum productivity
 - 🤝 **Agent Teams** - Coordinate specialized agents for complex workflows (code review, testing, docs)
@@ -261,7 +261,7 @@ cd my-ai-tools
 - `--dry-run` - Preview changes without making them
 - `--backup` - Backup existing configs before installing
 - `--no-backup` - Skip backup prompt
-- `-y` / `--yes` - Non-interactive mode; only installs/configures your active tool set (amp, codex, ctx, cursor, kilo, opencode, open_code_review, pi, omp, antigravity, ai-switcher, claude, reasonix). Shared infra (plugins, skills, global tools) still installed. Auto-activated in CI/piped input.
+- `-y` / `--yes` - Non-interactive mode; only installs/configures your active tool set (amp, codex, ctx, cursor, fx, kilo, opencode, open_code_review, pi, omp, antigravity, ai-switcher, claude, reasonix). Shared infra (plugins, skills, global tools) still installed. Auto-activated in CI/piped input.
 - `--migrate-gemini` - One-step Gemini→Antigravity CLI migration
 
 ## 🔄 Bidirectional Config Sync
@@ -283,6 +283,20 @@ Export your current configurations back to this repository for version control:
 ```
 
 > **Tip:** Use `generate.sh` after customizing your local setup to save changes back to this repo.
+
+## 𝒇x (Optional)
+
+[fx](https://fx.sh/) is a small native coding agent from Vercel Labs. The installer uses its official setup script on macOS and Linux, then installs this repository's global guidance to `~/.fx/AGENTS.md` when fx is detected.
+
+```bash
+# Install and configure fx interactively
+./cli.sh
+
+# Start fx in a project
+fx
+```
+
+fx discovers shared skills from `~/.agents/skills/`, so it uses this repository's universal skill installation automatically. Its MCP configuration at `~/.fx/mcp.json` and other runtime state remain private by design and are not managed by this repository.
 
 ## 🤖 Chat with the repo
 

--- a/cli.sh
+++ b/cli.sh
@@ -13,7 +13,7 @@ source "$SCRIPT_DIR/lib/install.sh"
 # Core tools installed/configured when -y (YES_TO_ALL) is active.
 # This is your personal active tool set. When YES_TO_ALL is false
 # (interactive mode), tool_allowed returns true for everything.
-TOOL_ALLOWLIST_YES=(amp codex ctx cursor kilo opencode open_code_review pi omp antigravity ai-switcher claude reasonix)
+TOOL_ALLOWLIST_YES=(amp codex ctx cursor fx kilo opencode open_code_review pi omp antigravity ai-switcher claude reasonix)
 
 tool_allowed() {
 	local name="$1"
@@ -35,6 +35,7 @@ INSTALL_SEQUENCE=(
 	"opencode:install_opencode"
 	"opencode:install_opencode2"
 	"opencode:install_open_cursor"
+	"fx:install_fx"
 	"amp:install_amp"
 	"always:install_global_tools"
 	"ccs:install_ccs"
@@ -330,6 +331,7 @@ backup_configs() {
 		copy_config_dir "$HOME/.claude" "$BACKUP_DIR" "claude"
 		copy_config_dir "$HOME/.config/opencode" "$BACKUP_DIR" "opencode"
 		copy_config_dir "$HOME/.config/amp" "$BACKUP_DIR" "amp"
+		copy_config_file "$HOME/.fx/AGENTS.md" "$BACKUP_DIR/fx" || true
 		copy_config_dir "$HOME/.codex" "$BACKUP_DIR" "codex"
 		copy_config_dir "$HOME/.kimi-code" "$BACKUP_DIR" "kimi-code"
 		copy_config_dir "$HOME/.gemini" "$BACKUP_DIR" "gemini"
@@ -497,6 +499,11 @@ copy_configurations() {
 		copy_opencode_configs
 	else
 		log_info "Skipping opencode config install (not in -y allowlist)"
+	fi
+	if tool_allowed "fx"; then
+		copy_fx_configs
+	else
+		log_info "Skipping fx config install (not in -y allowlist)"
 	fi
 	if tool_allowed "amp"; then
 		copy_amp_configs
@@ -1078,6 +1085,20 @@ copy_opencode_configs() {
 	copy_opencode_commands "$SCRIPT_DIR/configs/opencode/command" "$HOME/.config/opencode/command"
 
 	log_success "OpenCode configs copied"
+}
+
+copy_fx_configs() {
+	local fx_status
+	fx_status=$(detect_tool --detailed "fx" "$HOME/.fx") || fx_status="missing"
+	if [ "$fx_status" = "missing" ]; then
+		log_info "fx not detected - skipping fx config installation"
+		return 0
+	fi
+
+	log_info "Detected fx (via $fx_status)"
+	execute_quoted mkdir -p "$HOME/.fx"
+	copy_config_file "$SCRIPT_DIR/configs/fx/AGENTS.md" "$HOME/.fx/" || true
+	log_success "fx configs copied"
 }
 
 copy_amp_configs() {
@@ -2654,7 +2675,7 @@ main() {
 
 	echo "╔══════════════════════════════════════════════════════════════════════╗"
 	echo "║                        AI Tools Setup                                ║"
-	echo "║  Claude • OpenCode • Amp • CCS • Codex • Kimi Code • Gemini          ║"
+	echo "║  Claude • OpenCode • fx • Amp • CCS • Codex • Kimi Code • Gemini     ║"
 	echo "║  Antigravity • Pi • Kilo • Copilot • Cursor • Command Code           ║"
 	echo "║  Factory Droid • Cline • Grok • MiMo-Code • herdr                    ║"
 	echo "║  Qoder CLI • Kiro • Codiff • Devin • Hunk                            ║"

--- a/cli.sh
+++ b/cli.sh
@@ -1097,7 +1097,7 @@ copy_fx_configs() {
 
 	log_info "Detected fx (via $fx_status)"
 	execute_quoted mkdir -p "$HOME/.fx"
-	copy_config_file "$SCRIPT_DIR/configs/fx/AGENTS.md" "$HOME/.fx/" || true
+	copy_config_file "$SCRIPT_DIR/configs/fx/AGENTS.md" "$HOME/.fx/" || return 1
 	log_success "fx configs copied"
 }
 

--- a/configs/fx/AGENTS.md
+++ b/configs/fx/AGENTS.md
@@ -1,0 +1,51 @@
+# 🤖 fx Agent Guidelines
+
+## Communication
+
+Always talk in ASD-STE100 Simplified Technical English. Always read CONTEXT.md files if present, and use their ubiquitous language.
+
+## Session Management with tmux
+
+Run dev servers, tests, and interactive CLIs inside tmux with the **current directory name as the session name** for easy debugging:
+
+```bash
+SESSION=$(basename "$PWD")
+tmux new -d -s "$SESSION" 2>/dev/null || true
+
+# Run dev server with portless if available, otherwise fallback to npm
+if command -v portless &>/dev/null; then
+    tmux send-keys -t "$SESSION" 'portless run npm run dev' Enter
+else
+    tmux send-keys -t "$SESSION" 'npm run dev' Enter
+fi
+
+tmux capture-pane -p -t "$SESSION" -S -20  # check output
+```
+
+## AI Tool Guidelines
+
+- Use the fff MCP tools for all file search operations instead of default tools.
+- Use the sem MCP tools for semantic version control and git operations.
+- When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
+
+## Token Efficiency
+
+- Keep responses concise and actionable; lead with conclusions, file paths, and verification.
+- Scope searches and file reads to the task. Limit command output with filters and line ranges.
+- Use `~/.local/bin/rtk` for supported shell commands when available; bypass it with `RTK_DISABLED=1` when raw output is required.
+- Prefer `codebase-memory-mcp` graph tools for structural code discovery when available.
+- Load supplemental guidance only when the task requires it. Start a fresh session when switching to unrelated work.
+
+## General Practices
+
+- Read `~/.ai-tools/best-practices.md` only when the repository lacks equivalent guidance or the task needs its detailed workflow.
+- Read `~/.ai-tools/MEMORY.md` and `~/.ai-tools/agent-memory.md` only when deciding whether or where to persist a learning.
+- Read `~/.ai-tools/git-guidelines.md` before destructive or history-changing git operations.
+- Always propose a plan before edits. Use phases to break down tasks into manageable steps.
+- Run typecheck, lint and biome on js/ts file changes after finish.
+- Prefer to use Bun to run scripts if possible, otherwise use tsx to run ts files.
+- Ask before destructive operations — don't guess safety.
+- Code is communication — prefer clarity and simplicity.
+- Self-documenting code through meaningful names and structure.
+- Modular design that can evolve.
+- Comments explain why, not what.

--- a/configs/fx/AGENTS.md
+++ b/configs/fx/AGENTS.md
@@ -24,8 +24,8 @@ tmux capture-pane -p -t "$SESSION" -S -20  # check output
 
 ## AI Tool Guidelines
 
-- Use the fff MCP tools for all file search operations instead of default tools.
-- Use the sem MCP tools for semantic version control and git operations.
+- Use the fff MCP tools for file search when they are configured. Otherwise, use `fd` or `rg`.
+- Use the sem MCP tools for semantic version control when they are configured. Otherwise, use Git.
 - When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
 
 ## Token Efficiency

--- a/generate.sh
+++ b/generate.sh
@@ -241,6 +241,19 @@ generate_opencode_configs() {
 	log_success "OpenCode configs generated"
 }
 
+generate_fx_configs() {
+	log_info "Generating fx configs..."
+
+	if [ ! -d "$HOME/.fx" ]; then
+		log_warning "fx config directory not found: $HOME/.fx"
+		return 0
+	fi
+
+	execute_quoted mkdir -p "$SCRIPT_DIR/configs/fx"
+	copy_single "$HOME/.fx/AGENTS.md" "$SCRIPT_DIR/configs/fx/AGENTS.md"
+	log_success "fx configs generated"
+}
+
 generate_amp_configs() {
 	log_info "Generating Amp configs..."
 
@@ -1121,6 +1134,9 @@ main() {
 	echo
 
 	generate_opencode_configs
+	echo
+
+	generate_fx_configs
 	echo
 
 	generate_amp_configs

--- a/generate.sh
+++ b/generate.sh
@@ -248,6 +248,10 @@ generate_fx_configs() {
 		log_warning "fx config directory not found: $HOME/.fx"
 		return 0
 	fi
+	if [ ! -f "$HOME/.fx/AGENTS.md" ]; then
+		log_warning "fx config not found: $HOME/.fx/AGENTS.md"
+		return 0
+	fi
 
 	execute_quoted mkdir -p "$SCRIPT_DIR/configs/fx"
 	copy_single "$HOME/.fx/AGENTS.md" "$SCRIPT_DIR/configs/fx/AGENTS.md"

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -305,19 +305,27 @@ download_and_verify_file() {
 	temp_file="${tmpdir}/download-$(date +%s)-$$"
 
 	log_info "Downloading $description..."
-	if ! curl -fsSL "$url" -o "$temp_file" 2>/dev/null; then
+	if ! execute_quoted curl -fsSL "$url" -o "$temp_file" 2>/dev/null; then
 		log_error "Failed to download $description"
 		return 1
 	fi
 
 	if [ -n "$expected_sha256" ]; then
 		local actual_sha256
-		actual_sha256=$(sha256sum "$temp_file" 2>/dev/null | cut -d' ' -f1)
+		if command -v sha256sum &>/dev/null; then
+			actual_sha256=$(sha256sum "$temp_file" 2>/dev/null | cut -d' ' -f1)
+		elif command -v shasum &>/dev/null; then
+			actual_sha256=$(shasum -a 256 "$temp_file" 2>/dev/null | cut -d' ' -f1)
+		else
+			log_error "SHA-256 verification requires sha256sum or shasum"
+			execute_quoted rm -f "$temp_file"
+			return 1
+		fi
 		if [ "$actual_sha256" != "$expected_sha256" ]; then
 			log_error "Checksum verification failed for $description"
 			log_error "Expected: $expected_sha256"
 			log_error "Actual: $actual_sha256"
-			rm -f "$temp_file"
+			execute_quoted rm -f "$temp_file"
 			return 1
 		fi
 		log_success "Checksum verified for $description"
@@ -356,10 +364,10 @@ execute_installer() {
 		return 1
 	fi
 
-	chmod +x "$temp_script"
+	execute_quoted chmod +x "$temp_script"
 	"$temp_script" "$@"
 	local result=$?
-	rm -f "$temp_script"
+	execute_quoted rm -f "$temp_script"
 	return $result
 }
 

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -292,40 +292,38 @@ execute_quoted() {
 	fi
 }
 
-# Download and verify script with checksum (if available)
-# Usage: download_and_verify_script "url" "expected_sha256" "description"
-download_and_verify_script() {
+# Download and verify a file with SHA-256 (if available)
+# Usage: download_and_verify_file "url" "expected_sha256" "description"
+download_and_verify_file() {
 	local url="$1"
 	local expected_sha256="$2"
 	local description="$3"
 
 	local tmpdir
 	tmpdir=$(get_temp_dir)
-	local temp_script
-	temp_script="${tmpdir}/install-$(date +%s)-$$"
+	local temp_file
+	temp_file="${tmpdir}/download-$(date +%s)-$$"
 
 	log_info "Downloading $description..."
-	if ! curl -fsSL "$url" -o "$temp_script" 2>/dev/null; then
+	if ! curl -fsSL "$url" -o "$temp_file" 2>/dev/null; then
 		log_error "Failed to download $description"
 		return 1
 	fi
 
-	chmod +x "$temp_script"
-
 	if [ -n "$expected_sha256" ]; then
 		local actual_sha256
-		actual_sha256=$(sha256sum "$temp_script" 2>/dev/null | cut -d' ' -f1)
+		actual_sha256=$(sha256sum "$temp_file" 2>/dev/null | cut -d' ' -f1)
 		if [ "$actual_sha256" != "$expected_sha256" ]; then
 			log_error "Checksum verification failed for $description"
 			log_error "Expected: $expected_sha256"
 			log_error "Actual: $actual_sha256"
-			rm -f "$temp_script"
+			rm -f "$temp_file"
 			return 1
 		fi
 		log_success "Checksum verified for $description"
 	fi
 
-	echo "$temp_script"
+	echo "$temp_file"
 }
 
 # Execute external installer script with verification
@@ -353,11 +351,12 @@ execute_installer() {
 	export TMPDIR="$tmp_dir"
 
 	local temp_script
-	temp_script=$(download_and_verify_script "$url" "$expected_sha256" "$description")
+	temp_script=$(download_and_verify_file "$url" "$expected_sha256" "$description")
 	if [ -z "$temp_script" ]; then
 		return 1
 	fi
 
+	chmod +x "$temp_script"
 	"$temp_script" "$@"
 	local result=$?
 	rm -f "$temp_script"

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -252,6 +252,31 @@ install_claude_code() {
 	fi
 }
 
+install_fx() {
+	_run_fx_install() {
+		if command -v fx &>/dev/null; then
+			log_warning "fx is already installed"
+			return 0
+		fi
+
+		if [ "$IS_WINDOWS" = true ]; then
+			log_warning "fx supports macOS and Linux only."
+			log_info "Install fx manually in a supported environment: https://fx.sh/docs/getting-started/installation"
+			return 1
+		fi
+
+		if execute_installer "https://fx.sh/setup.sh" "" "fx"; then
+			ensure_dir_on_path "$HOME/.local/bin"
+			log_success "fx installed"
+		else
+			log_error "Failed to install fx"
+			log_info "You can install manually: curl -fsSL https://fx.sh/setup.sh | bash"
+			return 1
+		fi
+	}
+	run_installer "fx" "_run_fx_install" "command -v fx" "fx --version"
+}
+
 install_rtk() {
 	if [ "${IS_WINDOWS:-false}" = true ]; then
 		log_warning "RTK automatic installation is unavailable on native Windows"

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -254,6 +254,10 @@ install_claude_code() {
 
 install_fx() {
 	_run_fx_install() {
+		local fx_install_dir="${FX_INSTALL_DIR:-$HOME/.local/bin}"
+		local fx_version="v0.0.4"
+		local fx_setup_sha256="254c2d4410678aa28acb17941f5447b34b312f829893d4261bb4d713508f924f"
+
 		if command -v fx &>/dev/null; then
 			log_warning "fx is already installed"
 			return 0
@@ -265,8 +269,8 @@ install_fx() {
 			return 0
 		fi
 
-		if execute_installer "https://fx.sh/setup.sh" "" "fx"; then
-			ensure_dir_on_path "$HOME/.local/bin"
+		if execute_installer "https://fx.sh/setup.sh" "$fx_setup_sha256" "fx $fx_version" "$fx_version"; then
+			ensure_dir_on_path "$fx_install_dir"
 			log_success "fx installed"
 		else
 			log_error "Failed to install fx"

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -262,7 +262,7 @@ install_fx() {
 		if [ "$IS_WINDOWS" = true ]; then
 			log_warning "fx supports macOS and Linux only."
 			log_info "Install fx manually in a supported environment: https://fx.sh/docs/getting-started/installation"
-			return 1
+			return 0
 		fi
 
 		if execute_installer "https://fx.sh/setup.sh" "" "fx"; then

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -254,9 +254,10 @@ install_claude_code() {
 
 install_fx() {
 	_run_fx_install() {
+		local fx_platform
+		local fx_archive_sha256
 		local fx_install_dir="${FX_INSTALL_DIR:-$HOME/.local/bin}"
 		local fx_version="v0.0.4"
-		local fx_setup_sha256="254c2d4410678aa28acb17941f5447b34b312f829893d4261bb4d713508f924f"
 
 		if command -v fx &>/dev/null; then
 			log_warning "fx is already installed"
@@ -269,14 +270,53 @@ install_fx() {
 			return 0
 		fi
 
-		if execute_installer "https://fx.sh/setup.sh" "$fx_setup_sha256" "fx $fx_version" "$fx_version"; then
-			ensure_dir_on_path "$fx_install_dir"
-			log_success "fx installed"
-		else
+		case "$(uname -s):$(uname -m)" in
+		Linux:x86_64 | Linux:amd64)
+			fx_platform="linux-x86_64"
+			fx_archive_sha256="be9428636afb1196cb662b48ed57bbed3b95e7c37f2bc7849e02c0960fae1f01"
+			;;
+		Linux:arm64 | Linux:aarch64)
+			fx_platform="linux-aarch64"
+			fx_archive_sha256="9905a51c213d1b7fe3b5079f00fd3e61f2dba5bde707397991e9535c4a700caf"
+			;;
+		Darwin:x86_64 | Darwin:amd64)
+			fx_platform="macos-x86_64"
+			fx_archive_sha256="41d3c2cd78bdb53aa9df16fbd5ae9415c8a2e3e8851ebe6423db0cc32128bf7c"
+			;;
+		Darwin:arm64 | Darwin:aarch64)
+			fx_platform="macos-aarch64"
+			fx_archive_sha256="395ac3832f6f6c231f6ba7a46ba6ec70eefaddb68662e6fd6c4fb8e0d6d72f59"
+			;;
+		*)
+			log_error "Unsupported fx platform: $(uname -s) $(uname -m)"
+			return 1
+			;;
+		esac
+
+		if [ "$DRY_RUN" = true ]; then
+			log_info "[DRY RUN] Would install fx $fx_version for $fx_platform to $fx_install_dir"
+			return 0
+		fi
+
+		local fx_archive
+		local fx_extract_dir
+		fx_archive=$(download_and_verify_file "https://releases.fx.sh/$fx_version/fx-$fx_platform.tar.gz" "$fx_archive_sha256" "fx $fx_version ($fx_platform)") || return 1
+		fx_extract_dir="$(get_temp_dir)/fx-$fx_version-$$"
+
+		if ! execute_quoted mkdir -p "$fx_extract_dir" ||
+			! execute_quoted tar -xzf "$fx_archive" -C "$fx_extract_dir" ||
+			! execute_quoted mkdir -p "$fx_install_dir" ||
+			! execute_quoted cp "$fx_extract_dir/fx" "$fx_install_dir/fx" ||
+			! execute_quoted chmod +x "$fx_install_dir/fx"; then
+			execute_quoted rm -rf "$fx_extract_dir" "$fx_archive"
 			log_error "Failed to install fx"
 			log_info "You can install manually: curl -fsSL https://fx.sh/setup.sh | bash"
 			return 1
 		fi
+
+		execute_quoted rm -rf "$fx_extract_dir" "$fx_archive"
+		ensure_dir_on_path "$fx_install_dir"
+		log_success "fx installed"
 	}
 	run_installer "fx" "_run_fx_install" "command -v fx" "fx --version"
 }

--- a/tests/pr_fx.bats
+++ b/tests/pr_fx.bats
@@ -19,13 +19,16 @@ FX_CONFIG_DIR="$REPO_ROOT/configs/fx"
 	local install_dir="$BATS_TEST_TMPDIR/fx-custom-bin"
 	local archive_log="$BATS_TEST_TMPDIR/fx-archive-call"
 	local path_log="$BATS_TEST_TMPDIR/fx-installer-path"
-	mkdir -p "$test_home"
+	local archive_root="$BATS_TEST_TMPDIR/fx-archive-root"
+	local fake_archive="$BATS_TEST_TMPDIR/fx-test-archive.tar.gz"
+	mkdir -p "$test_home" "$archive_root"
+	printf '#!/bin/sh\nprintf "fx test binary\\n"\n' >"$archive_root/fx"
+	tar -czf "$fake_archive" -C "$archive_root" fx
 
-	run env HOME="$test_home" PATH="/usr/bin:/bin" FX_INSTALL_DIR="$install_dir" ARCHIVE_LOG="$archive_log" PATH_LOG="$path_log" REPO_ROOT="$REPO_ROOT" bash -c '
+	run env HOME="$test_home" PATH="/usr/bin:/bin" FX_INSTALL_DIR="$install_dir" FAKE_ARCHIVE="$fake_archive" ARCHIVE_LOG="$archive_log" PATH_LOG="$path_log" REPO_ROOT="$REPO_ROOT" bash -c '
 		export DRY_RUN=false YES_TO_ALL=true VERBOSE=false IS_WINDOWS=false
 		source "$REPO_ROOT/cli.sh"
-		download_and_verify_file() { printf "%s\n" "$@" >"$ARCHIVE_LOG"; printf "/tmp/fx-test-archive\n"; }
-		execute_quoted() { return 0; }
+		download_and_verify_file() { printf "%s\n" "$@" >"$ARCHIVE_LOG"; printf "%s\n" "$FAKE_ARCHIVE"; }
 		ensure_dir_on_path() { printf "%s\n" "$1" >"$PATH_LOG"; }
 		install_fx
 	'
@@ -35,6 +38,9 @@ FX_CONFIG_DIR="$REPO_ROOT/configs/fx"
 	[ "$output" = $'https://releases.fx.sh/v0.0.4/fx-linux-x86_64.tar.gz\nbe9428636afb1196cb662b48ed57bbed3b95e7c37f2bc7849e02c0960fae1f01\nfx v0.0.4 (linux-x86_64)' ]
 	run cat "$path_log"
 	[ "$output" = "$install_dir" ]
+	[ -x "$install_dir/fx" ]
+	run "$install_dir/fx"
+	[ "$output" = "fx test binary" ]
 }
 
 @test "copy_fx_configs installs guidance without changing private MCP state" {

--- a/tests/pr_fx.bats
+++ b/tests/pr_fx.bats
@@ -14,24 +14,25 @@ FX_CONFIG_DIR="$REPO_ROOT/configs/fx"
 	[ "$status" -eq 0 ]
 }
 
-@test "install_fx verifies a pinned release and honors FX_INSTALL_DIR" {
+@test "install_fx verifies a pinned archive and honors FX_INSTALL_DIR" {
 	local test_home="$BATS_TEST_TMPDIR/fx-install-home"
 	local install_dir="$BATS_TEST_TMPDIR/fx-custom-bin"
-	local call_log="$BATS_TEST_TMPDIR/fx-installer-call"
+	local archive_log="$BATS_TEST_TMPDIR/fx-archive-call"
 	local path_log="$BATS_TEST_TMPDIR/fx-installer-path"
 	mkdir -p "$test_home"
 
-	run env HOME="$test_home" PATH="/usr/bin:/bin" FX_INSTALL_DIR="$install_dir" CALL_LOG="$call_log" PATH_LOG="$path_log" REPO_ROOT="$REPO_ROOT" bash -c '
+	run env HOME="$test_home" PATH="/usr/bin:/bin" FX_INSTALL_DIR="$install_dir" ARCHIVE_LOG="$archive_log" PATH_LOG="$path_log" REPO_ROOT="$REPO_ROOT" bash -c '
 		export DRY_RUN=false YES_TO_ALL=true VERBOSE=false IS_WINDOWS=false
 		source "$REPO_ROOT/cli.sh"
-		execute_installer() { printf "%s\n" "$@" >"$CALL_LOG"; }
+		download_and_verify_file() { printf "%s\n" "$@" >"$ARCHIVE_LOG"; printf "/tmp/fx-test-archive\n"; }
+		execute_quoted() { return 0; }
 		ensure_dir_on_path() { printf "%s\n" "$1" >"$PATH_LOG"; }
 		install_fx
 	'
 
 	[ "$status" -eq 0 ]
-	run cat "$call_log"
-	[ "$output" = $'https://fx.sh/setup.sh\n254c2d4410678aa28acb17941f5447b34b312f829893d4261bb4d713508f924f\nfx v0.0.4\nv0.0.4' ]
+	run cat "$archive_log"
+	[ "$output" = $'https://releases.fx.sh/v0.0.4/fx-linux-x86_64.tar.gz\nbe9428636afb1196cb662b48ed57bbed3b95e7c37f2bc7849e02c0960fae1f01\nfx v0.0.4 (linux-x86_64)' ]
 	run cat "$path_log"
 	[ "$output" = "$install_dir" ]
 }

--- a/tests/pr_fx.bats
+++ b/tests/pr_fx.bats
@@ -14,31 +14,95 @@ FX_CONFIG_DIR="$REPO_ROOT/configs/fx"
 	[ "$status" -eq 0 ]
 }
 
-@test "cli.sh installs fx through the official setup script" {
-	run grep -F 'https://fx.sh/setup.sh' "$REPO_ROOT/lib/install.sh"
+@test "install_fx verifies a pinned release and honors FX_INSTALL_DIR" {
+	local test_home="$BATS_TEST_TMPDIR/fx-install-home"
+	local install_dir="$BATS_TEST_TMPDIR/fx-custom-bin"
+	local call_log="$BATS_TEST_TMPDIR/fx-installer-call"
+	local path_log="$BATS_TEST_TMPDIR/fx-installer-path"
+	mkdir -p "$test_home"
+
+	run env HOME="$test_home" PATH="/usr/bin:/bin" FX_INSTALL_DIR="$install_dir" CALL_LOG="$call_log" PATH_LOG="$path_log" REPO_ROOT="$REPO_ROOT" bash -c '
+		export DRY_RUN=false YES_TO_ALL=true VERBOSE=false IS_WINDOWS=false
+		source "$REPO_ROOT/cli.sh"
+		execute_installer() { printf "%s\n" "$@" >"$CALL_LOG"; }
+		ensure_dir_on_path() { printf "%s\n" "$1" >"$PATH_LOG"; }
+		install_fx
+	'
+
 	[ "$status" -eq 0 ]
+	run cat "$call_log"
+	[ "$output" = $'https://fx.sh/setup.sh\n254c2d4410678aa28acb17941f5447b34b312f829893d4261bb4d713508f924f\nfx v0.0.4\nv0.0.4' ]
+	run cat "$path_log"
+	[ "$output" = "$install_dir" ]
 }
 
-@test "cli.sh has copy_fx_configs function" {
-	run grep -F "copy_fx_configs()" "$REPO_ROOT/cli.sh"
+@test "copy_fx_configs installs guidance without changing private MCP state" {
+	local test_home="$BATS_TEST_TMPDIR/fx-copy-home"
+	mkdir -p "$test_home/.fx"
+	printf '{"private":true}\n' >"$test_home/.fx/mcp.json"
+
+	run env HOME="$test_home" REPO_ROOT="$REPO_ROOT" bash -c '
+		export DRY_RUN=false YES_TO_ALL=false VERBOSE=false
+		source "$REPO_ROOT/cli.sh"
+		copy_fx_configs
+	'
+
 	[ "$status" -eq 0 ]
+	cmp "$FX_CONFIG_DIR/AGENTS.md" "$test_home/.fx/AGENTS.md"
+	run cat "$test_home/.fx/mcp.json"
+	[ "$output" = '{"private":true}' ]
 }
 
-@test "cli.sh copies fx AGENTS.md without managing private MCP state" {
-	run grep -F 'configs/fx/AGENTS.md' "$REPO_ROOT/cli.sh"
-	[ "$status" -eq 0 ]
-	run grep -F 'configs/fx/mcp.json' "$REPO_ROOT/cli.sh"
+@test "copy_fx_configs fails instead of reporting success when guidance is missing" {
+	local test_home="$BATS_TEST_TMPDIR/fx-copy-failure-home"
+	local empty_repo="$BATS_TEST_TMPDIR/fx-empty-repo"
+	mkdir -p "$test_home/.fx" "$empty_repo/configs/fx"
+
+	run env HOME="$test_home" REPO_ROOT="$REPO_ROOT" EMPTY_REPO="$empty_repo" bash -c '
+		export DRY_RUN=false YES_TO_ALL=false VERBOSE=false
+		source "$REPO_ROOT/cli.sh"
+		SCRIPT_DIR="$EMPTY_REPO"
+		copy_fx_configs
+	'
+
 	[ "$status" -ne 0 ]
+	[[ "$output" != *"fx configs copied"* ]]
 }
 
-@test "generate.sh has generate_fx_configs function" {
-	run grep -F "generate_fx_configs()" "$REPO_ROOT/generate.sh"
+@test "generate_fx_configs exports only guidance" {
+	local test_home="$BATS_TEST_TMPDIR/fx-generate-home"
+	local output_repo="$BATS_TEST_TMPDIR/fx-output-repo"
+	mkdir -p "$test_home/.fx" "$output_repo"
+	printf '# fx test guidance\n' >"$test_home/.fx/AGENTS.md"
+	printf '{"private":true}\n' >"$test_home/.fx/mcp.json"
+
+	run env HOME="$test_home" REPO_ROOT="$REPO_ROOT" OUTPUT_REPO="$output_repo" bash -c '
+		export DRY_RUN=false VERBOSE=false
+		source "$REPO_ROOT/generate.sh"
+		SCRIPT_DIR="$OUTPUT_REPO"
+		generate_fx_configs
+	'
+
 	[ "$status" -eq 0 ]
+	[ -f "$output_repo/configs/fx/AGENTS.md" ]
+	[ ! -e "$output_repo/configs/fx/mcp.json" ]
+	run cat "$output_repo/configs/fx/AGENTS.md"
+	[ "$output" = "# fx test guidance" ]
 }
 
-@test "generate.sh exports only fx AGENTS.md" {
-	run grep -F '$HOME/.fx/AGENTS.md' "$REPO_ROOT/generate.sh"
+@test "generate_fx_configs does not report success when guidance is missing" {
+	local test_home="$BATS_TEST_TMPDIR/fx-generate-missing-home"
+	local output_repo="$BATS_TEST_TMPDIR/fx-missing-output-repo"
+	mkdir -p "$test_home/.fx" "$output_repo"
+
+	run env HOME="$test_home" REPO_ROOT="$REPO_ROOT" OUTPUT_REPO="$output_repo" bash -c '
+		export DRY_RUN=false VERBOSE=false
+		source "$REPO_ROOT/generate.sh"
+		SCRIPT_DIR="$OUTPUT_REPO"
+		generate_fx_configs
+	'
+
 	[ "$status" -eq 0 ]
-	run grep -F '$HOME/.fx/mcp.json' "$REPO_ROOT/generate.sh"
-	[ "$status" -ne 0 ]
+	[[ "$output" == *"fx config not found"* ]]
+	[[ "$output" != *"fx configs generated"* ]]
 }

--- a/tests/pr_fx.bats
+++ b/tests/pr_fx.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# Tests for configs/fx/ and fx CLI integration
+
+load helpers
+
+FX_CONFIG_DIR="$REPO_ROOT/configs/fx"
+
+@test "configs/fx/AGENTS.md exists" {
+	[ -f "$FX_CONFIG_DIR/AGENTS.md" ]
+}
+
+@test "configs/fx/AGENTS.md references tmux" {
+	run grep -F "tmux" "$FX_CONFIG_DIR/AGENTS.md"
+	[ "$status" -eq 0 ]
+}
+
+@test "cli.sh installs fx through the official setup script" {
+	run grep -F 'https://fx.sh/setup.sh' "$REPO_ROOT/lib/install.sh"
+	[ "$status" -eq 0 ]
+}
+
+@test "cli.sh has copy_fx_configs function" {
+	run grep -F "copy_fx_configs()" "$REPO_ROOT/cli.sh"
+	[ "$status" -eq 0 ]
+}
+
+@test "cli.sh copies fx AGENTS.md without managing private MCP state" {
+	run grep -F 'configs/fx/AGENTS.md' "$REPO_ROOT/cli.sh"
+	[ "$status" -eq 0 ]
+	run grep -F 'configs/fx/mcp.json' "$REPO_ROOT/cli.sh"
+	[ "$status" -ne 0 ]
+}
+
+@test "generate.sh has generate_fx_configs function" {
+	run grep -F "generate_fx_configs()" "$REPO_ROOT/generate.sh"
+	[ "$status" -eq 0 ]
+}
+
+@test "generate.sh exports only fx AGENTS.md" {
+	run grep -F '$HOME/.fx/AGENTS.md' "$REPO_ROOT/generate.sh"
+	[ "$status" -eq 0 ]
+	run grep -F '$HOME/.fx/mcp.json' "$REPO_ROOT/generate.sh"
+	[ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary
- install and configure the fx coding agent
- add bidirectional sync for the fx global AGENTS.md profile
- preserve fx MCP and runtime state as private data
- document and test the integration

## Verification
- `bash -n cli.sh generate.sh lib/*.sh lib/install.sh`
- `./scripts/sync-token-efficiency.sh --check`
- `git diff --check`
- `./cli.sh --dry-run --no-backup`
- temporary-home fx config-copy integration test

Bats is not installed in the orb. Biome ignores shell, Markdown, and Bats files in this repository configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for installing and configuring the fx CLI.
  - Included fx in setup options and the active tool set configured with `--yes`.
  - Added fx guidance for workflows, validation, safety, and tool usage.
  - Added documentation covering fx installation, usage, shared skills, and configuration.
  - Added verified, platform-specific installation archives and custom installation paths.

- **Bug Fixes**
  - Preserved private settings while generating fx configuration.
  - Improved handling of missing guidance and configuration-copy failures.

- **Tests**
  - Added integration coverage for fx installation, configuration, custom paths, and documentation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->