### PR TITLE
feat(codex): enable 1M context window for GPT-5.6 Sol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1381,33 +1381,40 @@ npm install -g @openai/codex
 Located in [`configs/codex/`](configs/codex/):
 
 - [`config.toml`](configs/codex/config.toml) - Main TOML configuration with MCP servers
+- [`1m.config.toml`](configs/codex/1m.config.toml) - Optional 1.05M context profile (`codex --profile 1m`)
 - [`AGENTS.md`](configs/codex/AGENTS.md) - Agent guidelines
 
-### 1M-token context window (GPT-5.6 Sol)
+### Optional 1.05M-token context profile (GPT-5.6 Sol)
 
-Codex defaults are tuned for performance and cost. If you want the full context budget for a model that supports it (for example `gpt-5.6-sol` with a documented ~1,050,000-token window), add or update these top-level keys in `~/.codex/config.toml` **before any `[section]` headers**:
+Codex defaults stay cost-tuned. This repo does **not** put a 1M+ window in [`configs/codex/config.toml`](configs/codex/config.toml). The optional profile [`configs/codex/1m.config.toml`](configs/codex/1m.config.toml) installs to `~/.codex/1m.config.toml`.
+
+GPT-5.6 Sol's documented limits are 1,050,000 total context, 922,000 max input, and 128,000 max output. The profile sets:
 
 ```toml
 model = "gpt-5.6-sol"
-model_context_window = 1000000
-model_auto_compact_token_limit = 900000
+model_context_window = 1050000
+model_auto_compact_token_limit = 794000
 ```
 
-- `model` selects the model.
-- `model_context_window` sets a one-million-token context budget.
-- `model_auto_compact_token_limit` starts automatic history compaction around 900,000 tokens, leaving headroom before the limit.
+Compaction starts at 794,000 tokens (922,000 − 128,000) so a full reply still fits under the input cap. Prompts over 272K input tokens are billed at 2× input and 1.5× output for the full request.
 
-Restart the Codex client and start a **new session** after saving.
+After `./cli.sh`, enable it for a session:
 
-To try the configuration for a single CLI session without changing defaults:
+```bash
+codex --profile 1m
+```
+
+Restart the Codex client and start a **new session** after installing.
+
+One-off CLI trial without a profile:
 
 ```bash
 codex -m gpt-5.6-sol \
-  -c model_context_window=1000000 \
-  -c model_auto_compact_token_limit=900000
+  -c model_context_window=1050000 \
+  -c model_auto_compact_token_limit=794000
 ```
 
-This repo's checked-in [`configs/codex/config.toml`](configs/codex/config.toml) already includes these values for `gpt-5.6-sol`.
+To merge these keys into `~/.codex/config.toml` instead, put them **before any `[section]` headers**.
 
 ### MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -1383,6 +1383,32 @@ Located in [`configs/codex/`](configs/codex/):
 - [`config.toml`](configs/codex/config.toml) - Main TOML configuration with MCP servers
 - [`AGENTS.md`](configs/codex/AGENTS.md) - Agent guidelines
 
+### 1M-token context window (GPT-5.6 Sol)
+
+Codex defaults are tuned for performance and cost. If you want the full context budget for a model that supports it (for example `gpt-5.6-sol` with a documented ~1,050,000-token window), add or update these top-level keys in `~/.codex/config.toml` **before any `[section]` headers**:
+
+```toml
+model = "gpt-5.6-sol"
+model_context_window = 1000000
+model_auto_compact_token_limit = 900000
+```
+
+- `model` selects the model.
+- `model_context_window` sets a one-million-token context budget.
+- `model_auto_compact_token_limit` starts automatic history compaction around 900,000 tokens, leaving headroom before the limit.
+
+Restart the Codex client and start a **new session** after saving.
+
+To try the configuration for a single CLI session without changing defaults:
+
+```bash
+codex -m gpt-5.6-sol \
+  -c model_context_window=1000000 \
+  -c model_auto_compact_token_limit=900000
+```
+
+This repo's checked-in [`configs/codex/config.toml`](configs/codex/config.toml) already includes these values for `gpt-5.6-sol`.
+
 ### MCP Servers
 
 ```toml

--- a/cli.sh
+++ b/cli.sh
@@ -1164,6 +1164,7 @@ copy_codex_configs() {
 	copy_config_file "$SCRIPT_DIR/configs/codex/config.json" "$HOME/.codex/" || true
 
 	copy_config_file "$SCRIPT_DIR/configs/codex/config.toml" "$HOME/.codex/" || true
+	copy_config_file "$SCRIPT_DIR/configs/codex/1m.config.toml" "$HOME/.codex/" || true
 
 	if [ -d "$SCRIPT_DIR/configs/codex/themes" ]; then
 		execute_quoted mkdir -p "$HOME/.codex/themes"

--- a/configs/codex/1m.config.toml
+++ b/configs/codex/1m.config.toml
@@ -1,0 +1,9 @@
+# Optional Codex profile for the full GPT-5.6 Sol context budget.
+# Select with: codex --profile 1m
+#
+# gpt-5.6-sol: 1,050,000 window, 922,000 max input, 128,000 max output.
+# Compact at 794000 (922000 - 128000) so a full reply still fits under the input cap.
+# Prompts over 272K input tokens are billed at 2x input and 1.5x output for the request.
+model = "gpt-5.6-sol"
+model_context_window = 1050000
+model_auto_compact_token_limit = 794000

--- a/configs/codex/config.toml
+++ b/configs/codex/config.toml
@@ -1,6 +1,10 @@
 model_personality = "pragmatic"
 model = "gpt-5.6-sol"
 model_reasoning_effort = "low"
+# GPT-5.6 Sol supports ~1,050,000 tokens. Defaults are tuned for cost/perf; raise the
+# budget here when you need more code, tool output, and history before compaction.
+model_context_window = 1000000
+model_auto_compact_token_limit = 900000
 approvals_reviewer = "guardian_subagent"
 personality = "pragmatic"
 

--- a/configs/codex/config.toml
+++ b/configs/codex/config.toml
@@ -1,10 +1,6 @@
 model_personality = "pragmatic"
 model = "gpt-5.6-sol"
 model_reasoning_effort = "low"
-# GPT-5.6 Sol supports ~1,050,000 tokens. Defaults are tuned for cost/perf; raise the
-# budget here when you need more code, tool output, and history before compaction.
-model_context_window = 1000000
-model_auto_compact_token_limit = 900000
 approvals_reviewer = "guardian_subagent"
 personality = "pragmatic"
 

--- a/generate.sh
+++ b/generate.sh
@@ -293,6 +293,7 @@ generate_codex_configs() {
 	copy_single "$HOME/.codex/AGENTS.md" "$SCRIPT_DIR/configs/codex/AGENTS.md"
 	copy_single "$HOME/.codex/config.json" "$SCRIPT_DIR/configs/codex/config.json"
 	copy_single "$HOME/.codex/config.toml" "$SCRIPT_DIR/configs/codex/config.toml"
+	copy_single "$HOME/.codex/1m.config.toml" "$SCRIPT_DIR/configs/codex/1m.config.toml"
 
 	# Export agents
 	if [ -d "$HOME/.codex/agents" ]; then

--- a/tests/pr_codex.bats
+++ b/tests/pr_codex.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# Tests for configs/codex/ and Codex CLI integration
+
+load helpers
+
+CODEX_CONFIG_DIR="$REPO_ROOT/configs/codex"
+README_FILE="$REPO_ROOT/README.md"
+
+@test "configs/codex/AGENTS.md exists" {
+	[ -f "$CODEX_CONFIG_DIR/AGENTS.md" ]
+}
+
+@test "configs/codex/config.toml exists" {
+	[ -f "$CODEX_CONFIG_DIR/config.toml" ]
+}
+
+@test "configs/codex/config.toml selects gpt-5.6-sol" {
+	run grep -F 'model = "gpt-5.6-sol"' "$CODEX_CONFIG_DIR/config.toml"
+	[ "$status" -eq 0 ]
+}
+
+@test "configs/codex/config.toml sets 1M context window" {
+	run grep -F "model_context_window = 1000000" "$CODEX_CONFIG_DIR/config.toml"
+	[ "$status" -eq 0 ]
+}
+
+@test "configs/codex/config.toml sets auto-compact limit" {
+	run grep -F "model_auto_compact_token_limit = 900000" "$CODEX_CONFIG_DIR/config.toml"
+	[ "$status" -eq 0 ]
+}
+
+@test "configs/codex/config.toml has mcp_servers section" {
+	run grep -F "[mcp_servers." "$CODEX_CONFIG_DIR/config.toml"
+	[ "$status" -eq 0 ]
+}
+
+@test "configs/codex/config.toml references context7 MCP server" {
+	run grep -F "context7" "$CODEX_CONFIG_DIR/config.toml"
+	[ "$status" -eq 0 ]
+}
+
+@test "README.md Codex section documents 1M context window" {
+	run grep -F "model_context_window = 1000000" "$README_FILE"
+	[ "$status" -eq 0 ]
+}
+
+@test "README.md Codex section documents one-off CLI override" {
+	run grep -F "model_auto_compact_token_limit=900000" "$README_FILE"
+	[ "$status" -eq 0 ]
+}

--- a/tests/pr_codex.bats
+++ b/tests/pr_codex.bats
@@ -4,47 +4,91 @@
 load helpers
 
 CODEX_CONFIG_DIR="$REPO_ROOT/configs/codex"
+CODEX_CONFIG="$CODEX_CONFIG_DIR/config.toml"
+CODEX_1M_PROFILE="$CODEX_CONFIG_DIR/1m.config.toml"
 README_FILE="$REPO_ROOT/README.md"
+CLI_SH="$REPO_ROOT/cli.sh"
+GENERATE_SH="$REPO_ROOT/generate.sh"
+
+toml_keys_before_tables() {
+	local file="$1"
+	local first_table
+	first_table=$(grep -n -E '^\[' "$file" | head -1 | cut -d: -f1)
+	[ -z "$first_table" ] && return 0
+
+	local key
+	for key in model_context_window model_auto_compact_token_limit; do
+		local key_line
+		key_line=$(grep -n -E "^${key}[[:space:]]*=" "$file" | head -1 | cut -d: -f1)
+		[ -n "$key_line" ]
+		[ "$key_line" -lt "$first_table" ]
+	done
+}
 
 @test "configs/codex/AGENTS.md exists" {
 	[ -f "$CODEX_CONFIG_DIR/AGENTS.md" ]
 }
 
-@test "configs/codex/config.toml exists" {
-	[ -f "$CODEX_CONFIG_DIR/config.toml" ]
+@test "configs/codex/config.toml exists and is valid TOML" {
+	[ -f "$CODEX_CONFIG" ]
+	run bash -c 'source "$1/lib/common.sh"; validate_config "$2"' _ "$REPO_ROOT" "$CODEX_CONFIG"
+	[ "$status" -eq 0 ]
 }
 
 @test "configs/codex/config.toml selects gpt-5.6-sol" {
-	run grep -F 'model = "gpt-5.6-sol"' "$CODEX_CONFIG_DIR/config.toml"
+	run grep -E '^model[[:space:]]*=[[:space:]]*"gpt-5.6-sol"' "$CODEX_CONFIG"
 	[ "$status" -eq 0 ]
 }
 
-@test "configs/codex/config.toml sets 1M context window" {
-	run grep -F "model_context_window = 1000000" "$CODEX_CONFIG_DIR/config.toml"
-	[ "$status" -eq 0 ]
-}
-
-@test "configs/codex/config.toml sets auto-compact limit" {
-	run grep -F "model_auto_compact_token_limit = 900000" "$CODEX_CONFIG_DIR/config.toml"
-	[ "$status" -eq 0 ]
+@test "configs/codex/config.toml does not set a 1M context window" {
+	run grep -E '^model_context_window[[:space:]]*=' "$CODEX_CONFIG"
+	[ "$status" -ne 0 ]
+	run grep -E '^model_auto_compact_token_limit[[:space:]]*=' "$CODEX_CONFIG"
+	[ "$status" -ne 0 ]
 }
 
 @test "configs/codex/config.toml has mcp_servers section" {
-	run grep -F "[mcp_servers." "$CODEX_CONFIG_DIR/config.toml"
+	run grep -F "[mcp_servers." "$CODEX_CONFIG"
 	[ "$status" -eq 0 ]
 }
 
 @test "configs/codex/config.toml references context7 MCP server" {
-	run grep -F "context7" "$CODEX_CONFIG_DIR/config.toml"
+	run grep -F "context7" "$CODEX_CONFIG"
 	[ "$status" -eq 0 ]
 }
 
-@test "README.md Codex section documents 1M context window" {
-	run grep -F "model_context_window = 1000000" "$README_FILE"
+@test "configs/codex/1m.config.toml exists and is valid TOML" {
+	[ -f "$CODEX_1M_PROFILE" ]
+	run bash -c 'source "$1/lib/common.sh"; validate_config "$2"' _ "$REPO_ROOT" "$CODEX_1M_PROFILE"
 	[ "$status" -eq 0 ]
 }
 
-@test "README.md Codex section documents one-off CLI override" {
-	run grep -F "model_auto_compact_token_limit=900000" "$README_FILE"
+@test "configs/codex/1m.config.toml uses gpt-5.6-sol input-safe window and compact limits" {
+	run grep -E '^model_context_window[[:space:]]*=[[:space:]]*1050000$' "$CODEX_1M_PROFILE"
+	[ "$status" -eq 0 ]
+	run grep -E '^model_auto_compact_token_limit[[:space:]]*=[[:space:]]*794000$' "$CODEX_1M_PROFILE"
+	[ "$status" -eq 0 ]
+	toml_keys_before_tables "$CODEX_1M_PROFILE"
+}
+
+@test "cli.sh and generate.sh round-trip the 1m Codex profile" {
+	run grep -F 'configs/codex/1m.config.toml' "$CLI_SH"
+	[ "$status" -eq 0 ]
+	run grep -F 'copy_config_file "$SCRIPT_DIR/configs/codex/1m.config.toml" "$HOME/.codex/"' "$CLI_SH"
+	[ "$status" -eq 0 ]
+	run grep -F 'copy_single "$HOME/.codex/1m.config.toml" "$SCRIPT_DIR/configs/codex/1m.config.toml"' "$GENERATE_SH"
+	[ "$status" -eq 0 ]
+}
+
+@test "README.md documents the optional 1m profile and long-context pricing" {
+	run grep -F "codex --profile 1m" "$README_FILE"
+	[ "$status" -eq 0 ]
+	run grep -F "model_context_window = 1050000" "$README_FILE"
+	[ "$status" -eq 0 ]
+	run grep -F "model_auto_compact_token_limit = 794000" "$README_FILE"
+	[ "$status" -eq 0 ]
+	run grep -F "model_auto_compact_token_limit=794000" "$README_FILE"
+	[ "$status" -eq 0 ]
+	run grep -F "272K" "$README_FILE"
 	[ "$status" -eq 0 ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Documents and applies Codex's optional 1M-token context budget for `gpt-5.6-sol`.

## Why

Codex defaults are tuned for performance and cost, but `gpt-5.6-sol` supports a documented ~1,050,000-token window. This is a common ask when you want more code, tool output, and conversation history before compaction.

## Changes

- **`configs/codex/config.toml`** — adds top-level `model_context_window = 1000000` and `model_auto_compact_token_limit = 900000` (with comments) alongside the existing `gpt-5.6-sol` default.
- **`README.md`** — Codex section explains the settings, restart/new-session requirement, and one-off CLI override via `-c` flags.
- **`tests/pr_codex.bats`** — regression tests for config values and README documentation (9 tests).

## How to use after merge

1. Run `./cli.sh` (or copy `configs/codex/config.toml` to `~/.codex/config.toml`).
2. Restart Codex and start a **new session**.

One-off CLI trial without changing defaults:

```bash
codex -m gpt-5.6-sol \
  -c model_context_window=1000000 \
  -c model_auto_compact_token_limit=900000
```

## Testing

```bash
bats tests/pr_codex.bats
```

All 9 tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://aircarbon.slack.com/archives/D093XS4DD53/p1787181155813379?thread_ts=1787181155.813379&cid=D093XS4DD53)

<div><a href="https://cursor.com/agents/bc-05adf2a0-ffba-51e7-a41e-0425f4b79be2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05adf2a0-ffba-51e7-a41e-0425f4b79be2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional Codex CLI profile for GPT-5.6 Sol with a 1,050,000-token context window.
  - Configured automatic context compaction at 794,000 tokens.
  - Setup and export scripts now include the new profile automatically.

- **Documentation**
  - Added usage instructions for the `1m` profile, one-off configuration, context limits, compaction behavior, and pricing considerations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->