### PR TITLE
feat: add Delta coding tool support

### DIFF
--- a/.changeset/add-delta-support.md
+++ b/.changeset/add-delta-support.md
@@ -1,0 +1,8 @@
+---
+"my-ai-tools": minor
+---
+
+Add Delta as a first-class supported tool with platform-aware configuration
+install/export support, managed personal agent rules and settings, official
+manual installation guidance, and functional coverage. Provider `.env` files
+remain local because they contain API credentials.

--- a/README.md
+++ b/README.md
@@ -3078,6 +3078,7 @@ Expand-Archive .\delta-windows-<architecture>.zip .\Delta
 Run this repo's installer after Delta is present to deploy the managed configuration:
 
 ```bash
+./cli.sh --dry-run
 ./cli.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -3068,6 +3068,13 @@ Download the build for your operating system and processor from Delta's official
 xattr -dr com.apple.quarantine /Applications/Delta.app
 ```
 
+On Windows, run `delta-windows-<architecture>-setup.exe` for a per-user installation. If a setup executable is not available, extract and launch the portable build from PowerShell:
+
+```powershell
+Expand-Archive .\delta-windows-<architecture>.zip .\Delta
+.\Delta\delta.exe
+```
+
 Run this repo's installer after Delta is present to deploy the managed configuration:
 
 ```bash
@@ -3097,7 +3104,17 @@ Provider credentials may be stored in `~/.config/delta/.env`, but this integrati
 ```bash
 # Linux: launch Delta after running ./Delta/install.sh delta
 delta
+
+# macOS
+open /Applications/Delta.app
 ```
+
+```powershell
+# Windows portable installation
+.\Delta\delta.exe
+```
+
+For the Windows setup installation, launch Delta from the Start menu.
 
 See Delta's [getting-started guide](https://delta.dev/docs/getting-started) and [settings reference](https://delta.dev/docs/configuration/settings) for current details.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub license](https://img.shields.io/github/license/jellydn/my-ai-tools)](https://github.com/jellydn/my-ai-tools/blob/main/LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/jellydn/my-ai-tools/pulls)
 
-> **Comprehensive configuration management for AI coding tools** - Replicate my complete setup for Claude Code, OpenCode, fx, Amp, Kilo CLI, Codex, Devin CLI, Kimi Code, Gemini CLI, Antigravity CLI, Pi, Oh My Pi, GitHub Copilot CLI, Cursor Agent CLI, Factory Droid, Cline, Grok CLI, MiMo-Code, Qoder CLI, Kiro CLI, Hunk, Codiff, ctx, Open Code Review, CCS, and Reasonix with custom configurations, MCP servers, skills, plugins, and commands.
+> **Comprehensive configuration management for AI coding tools** - Replicate my complete setup for Claude Code, OpenCode, fx, Amp, Kilo CLI, Codex, Devin CLI, Kimi Code, Gemini CLI, Antigravity CLI, Pi, Oh My Pi, GitHub Copilot CLI, Cursor Agent CLI, Factory Droid, Cline, Grok CLI, MiMo-Code, Qoder CLI, Kiro CLI, Delta, Hunk, Codiff, ctx, Open Code Review, CCS, and Reasonix with custom configurations, MCP servers, skills, plugins, and commands.
 
 📖 **[View Documentation Website](https://ai-tools.itman.fyi)** - Interactive landing page with full documentation and search.
 
@@ -12,7 +12,7 @@
 
 - 🚀 **One-line installer** - Get started in seconds
 - 🔄 **Bidirectional sync** - Install configs or export your current setup
-- 🤖 **Multiple AI tools** - Claude Code, OpenCode, fx, Amp, CCS, Devin, Kimi Code, Gemini, Antigravity, Grok, MiMo-Code, Qoder CLI, Kiro CLI, Hunk, Codiff, ctx, Open Code Review, Reasonix, and more
+- 🤖 **Multiple AI tools** - Claude Code, OpenCode, fx, Amp, CCS, Devin, Kimi Code, Gemini, Antigravity, Grok, MiMo-Code, Qoder CLI, Kiro CLI, Delta, Hunk, Codiff, ctx, Open Code Review, Reasonix, and more
 - 🔌 **MCP Server integration** - Context7, Sequential-thinking, qmd, codebase-memory-mcp, agentmemory, sem, ctx
 - 🎯 **Custom agents & skills** - Pre-configured for maximum productivity
 - 🤝 **Agent Teams** - Coordinate specialized agents for complex workflows (code review, testing, docs)
@@ -169,6 +169,7 @@ The lead hands off exact skill paths plus `OBJECTIVE / FILES / INTERFACES / CONS
 | **Qoder CLI**   | context7, sequential-thinking, qmd, codebase-memory-mcp, agentmemory, fff, react-grab-mcp, logpilot, sem, ctx              | -                                                                                                                                                                                                                                              |
 | **Kiro CLI**    | context7, sequential-thinking, qmd, codebase-memory-mcp, agentmemory, fff, react-grab-mcp, logpilot, sem, ctx              | Steering files (AGENTS.md), slash commands, MCP servers, ACP                                                                                                                                                                                   |
 | **Reasonix**    | context7, sequential-thinking, qmd, codebase-memory-mcp, agentmemory, fff, react-grab-mcp, logpilot, sem, ctx              | DeepSeek-native; prefix-cache loop; `[[plugins]]` MCP in config.toml; ACP (`reasonix acp`); `REASONIX.md`/`AGENTS.md` memory; Kanagawa theme staged                                                                                            |
+| **Delta**       | — (desktop app — model providers are configured in settings)                                                              | Personal rules (`~/.config/delta/AGENTS.md`), isolated checkouts, collaborative threads                                                                                                                                                        |
 | **Codiff**      | — (desktop app — uses configured agent backend via settings)                                                               | —                                                                                                                                                                                                                                              |
 
 ### 📋 MCP Server Details
@@ -3043,6 +3044,62 @@ hunk session list  # List live review sessions for agent interaction
 The recommended [Hunk Review skill](https://github.com/modem-dev/hunk/blob/main/skills/hunk-review/SKILL.md) teaches coding agents to inspect live sessions and add inline comments without launching the interactive TUI themselves.
 
 See the official [install guide](https://www.hunk.dev/docs/start/install/) and [config reference](https://www.hunk.dev/docs/reference/config) for all platforms and preferences.
+
+</details>
+
+---
+
+## 🔺 Delta (Optional)
+
+Collaborative agent workspace for running coding agents in isolated checkouts, reviewing their work, and syncing changes back to a repository. Delta is currently in beta and publishes nightly builds. [Homepage](https://delta.dev) | [Getting Started](https://delta.dev/docs/getting-started) | [Download](https://delta.dev/download)
+
+<details>
+<summary><strong>Installation &amp; Configuration</strong></summary>
+
+### Installation
+
+Download the build for your operating system and processor from Delta's official download page. Delta does not currently publish a stable package-manager or unattended installer URL, so this repository prints the official links instead of downloading a nightly build automatically.
+
+```bash
+# Linux: after extracting delta-linux-<architecture>.tar.gz
+./Delta/install.sh delta
+
+# macOS: after moving Delta.app into /Applications
+xattr -dr com.apple.quarantine /Applications/Delta.app
+```
+
+Run this repo's installer after Delta is present to deploy the managed configuration:
+
+```bash
+./cli.sh
+```
+
+### Configuration
+
+Delta configs are stored in [`configs/delta/`](configs/delta/):
+
+- [`settings.json`](configs/delta/settings.json) — Message, diff, notification, and review-link preferences
+- [`AGENTS.md`](configs/delta/AGENTS.md) — Personal rules loaded by Delta in every thread
+
+The installer and generator honor `DELTA_CONFIG_DIR`. Without that override, Delta uses these documented locations:
+
+| Config        | macOS                                                | Linux                                                   | Windows                               |
+| ------------- | ---------------------------------------------------- | ------------------------------------------------------- | ------------------------------------- |
+| Settings      | `~/Library/Application Support/delta/settings.json` | `$XDG_CONFIG_HOME/delta/settings.json` or `~/.config/delta/settings.json` | `%APPDATA%\delta\settings.json`      |
+| Personal rules | `~/.config/delta/AGENTS.md`                         | `~/.config/delta/AGENTS.md`                             | `%USERPROFILE%\.config\delta\AGENTS.md` |
+
+Delta checks `AGENT.md` before `AGENTS.md`; an existing non-empty `~/.config/delta/AGENT.md` therefore takes precedence over this managed profile.
+
+Provider credentials may be stored in `~/.config/delta/.env`, but this integration intentionally does not install, export, or commit that secret-bearing file. Sign in and connect a model provider through Delta's settings, or manage `.env` locally.
+
+### Usage
+
+```bash
+# Linux: launch Delta after running ./Delta/install.sh delta
+delta
+```
+
+See Delta's [getting-started guide](https://delta.dev/docs/getting-started) and [settings reference](https://delta.dev/docs/configuration/settings) for current details.
 
 </details>
 

--- a/cli.sh
+++ b/cli.sh
@@ -57,6 +57,7 @@ INSTALL_SEQUENCE=(
 	"hunk:install_hunk"
 	"qodercli:install_qodercli"
 	"kiro:install_kiro"
+	"delta:install_delta"
 	"codiff:install_codiff"
 	"devin:install_devin"
 	"factory:install_factory"
@@ -349,6 +350,8 @@ backup_configs() {
 		copy_config_dir "$HOME/.config/mimocode" "$BACKUP_DIR" "mimocode"
 		copy_config_dir "$HOME/.qoder" "$BACKUP_DIR" "qodercli"
 		copy_config_dir "$HOME/.kiro" "$BACKUP_DIR" "kiro"
+		copy_config_dir "$(get_delta_settings_dir)" "$BACKUP_DIR/delta" "settings"
+		copy_config_file "$HOME/.config/delta/AGENTS.md" "$BACKUP_DIR/delta" || true
 		copy_config_dir "$HOME/.codiff" "$BACKUP_DIR" "codiff"
 		copy_config_dir "$HOME/.config/devin" "$BACKUP_DIR" "devin"
 		copy_config_dir "$HOME/.ctx" "$BACKUP_DIR" "ctx"
@@ -600,6 +603,11 @@ copy_configurations() {
 	else
 		log_info "Skipping kiro config install (not in -y allowlist)"
 	fi
+	if tool_allowed "delta"; then
+		copy_delta_configs
+	else
+		log_info "Skipping delta config install (not in -y allowlist)"
+	fi
 	if tool_allowed "codiff"; then
 		copy_codiff_configs
 	else
@@ -651,6 +659,7 @@ _validate_config_tool_name() {
 		*kilo/config.json*) echo "kilo" ;;
 		*reasonix/config.toml*) echo "reasonix" ;;
 		*hunk/config.toml*) echo "hunk" ;;
+		*delta/settings.json*) echo "delta" ;;
 		*kimi-code/*.json* | *kimi-code/*.toml*) echo "kimi_code" ;;
 		*pi/settings.json*) echo "pi" ;;
 		*omp/*.yml* | *omp/*.yaml* | *omp/*.json*) echo "omp" ;;
@@ -697,6 +706,7 @@ validate_all_configs() {
 		"$SCRIPT_DIR/configs/kilo/config.json" \
 		"$SCRIPT_DIR/configs/reasonix/config.toml" \
 		"$SCRIPT_DIR/configs/hunk/config.toml" \
+		"$SCRIPT_DIR/configs/delta/settings.json" \
 		"$SCRIPT_DIR/configs/kimi-code/config.toml" \
 		"$SCRIPT_DIR/configs/kimi-code/mcp.json" \
 		"$SCRIPT_DIR/configs/pi/settings.json" \
@@ -1911,6 +1921,27 @@ copy_kiro_configs() {
 	log_success "Kiro CLI configs copied"
 }
 
+copy_delta_configs() {
+	local delta_settings_dir
+	delta_settings_dir=$(get_delta_settings_dir)
+	local delta_status
+	delta_status="missing"
+	if [ -d "$delta_settings_dir" ]; then
+		delta_status="directory"
+	elif [ -d "$HOME/.local/delta.app" ] || [ -d "/Applications/Delta.app" ]; then
+		delta_status="application"
+	else
+		log_info "Delta not detected - skipping Delta config installation"
+		return 0
+	fi
+
+	log_info "Detected Delta (via $delta_status)"
+	copy_config_file "$SCRIPT_DIR/configs/delta/settings.json" "$delta_settings_dir/" || true
+	copy_config_file "$SCRIPT_DIR/configs/delta/AGENTS.md" "$HOME/.config/delta/" || true
+
+	log_success "Delta configs copied"
+}
+
 copy_codiff_configs() {
 	log_info "Copying Codiff configs..."
 	execute_quoted mkdir -p "$HOME/.codiff"
@@ -2678,7 +2709,7 @@ main() {
 	echo "║  Claude • OpenCode • fx • Amp • CCS • Codex • Kimi Code • Gemini     ║"
 	echo "║  Antigravity • Pi • Kilo • Copilot • Cursor • Command Code           ║"
 	echo "║  Factory Droid • Cline • Grok • MiMo-Code • herdr                    ║"
-	echo "║  Qoder CLI • Kiro • Codiff • Devin • Hunk                            ║"
+	echo "║  Qoder CLI • Kiro • Delta • Codiff • Devin • Hunk                    ║"
 	echo "║  ctx • Reasonix                                                       ║"
 	echo "╚══════════════════════════════════════════════════════════════════════╝"
 	echo

--- a/cli.sh
+++ b/cli.sh
@@ -350,7 +350,7 @@ backup_configs() {
 		copy_config_dir "$HOME/.config/mimocode" "$BACKUP_DIR" "mimocode"
 		copy_config_dir "$HOME/.qoder" "$BACKUP_DIR" "qodercli"
 		copy_config_dir "$HOME/.kiro" "$BACKUP_DIR" "kiro"
-		copy_config_dir "$(get_delta_settings_dir)" "$BACKUP_DIR/delta" "settings"
+		copy_config_file "$(get_delta_settings_dir)/settings.json" "$BACKUP_DIR/delta" || true
 		copy_config_file "$HOME/.config/delta/AGENTS.md" "$BACKUP_DIR/delta" || true
 		copy_config_dir "$HOME/.codiff" "$BACKUP_DIR" "codiff"
 		copy_config_dir "$HOME/.config/devin" "$BACKUP_DIR" "devin"
@@ -1936,8 +1936,14 @@ copy_delta_configs() {
 	fi
 
 	log_info "Detected Delta (via $delta_status)"
-	copy_config_file "$SCRIPT_DIR/configs/delta/settings.json" "$delta_settings_dir/" || true
-	copy_config_file "$SCRIPT_DIR/configs/delta/AGENTS.md" "$HOME/.config/delta/" || true
+	if ! copy_config_file "$SCRIPT_DIR/configs/delta/settings.json" "$delta_settings_dir/"; then
+		log_error "Failed to copy Delta settings"
+		return 1
+	fi
+	if ! copy_config_file "$SCRIPT_DIR/configs/delta/AGENTS.md" "$HOME/.config/delta/"; then
+		log_error "Failed to copy Delta personal rules"
+		return 1
+	fi
 
 	log_success "Delta configs copied"
 }

--- a/cli.sh
+++ b/cli.sh
@@ -13,7 +13,7 @@ source "$SCRIPT_DIR/lib/install.sh"
 # Core tools installed/configured when -y (YES_TO_ALL) is active.
 # This is your personal active tool set. When YES_TO_ALL is false
 # (interactive mode), tool_allowed returns true for everything.
-TOOL_ALLOWLIST_YES=(amp codex ctx cursor fx kilo opencode open_code_review pi omp antigravity ai-switcher claude reasonix)
+TOOL_ALLOWLIST_YES=(amp codex ctx cursor delta fx kilo opencode open_code_review pi omp antigravity ai-switcher claude reasonix)
 
 tool_allowed() {
 	local name="$1"

--- a/configs/delta/AGENTS.md
+++ b/configs/delta/AGENTS.md
@@ -1,0 +1,50 @@
+# 🤖 Delta Agent Guidelines
+
+## Communication
+
+Always talk in ASD-STE100 Simplified Technical English. Always read CONTEXT.md files if present, and use their ubiquitous language.
+
+## Session Management with tmux
+
+Run dev servers, tests, and interactive CLIs inside tmux with the **current directory name as the session name** for easy debugging:
+
+```bash
+SESSION=$(basename "$PWD")
+tmux new -d -s "$SESSION" 2>/dev/null || true
+
+# Run dev server with portless if available, otherwise fallback to npm
+if command -v portless &>/dev/null; then
+    tmux send-keys -t "$SESSION" 'portless run npm run dev' Enter
+else
+    tmux send-keys -t "$SESSION" 'npm run dev' Enter
+fi
+
+tmux capture-pane -p -t "$SESSION" -S -20  # check output
+```
+
+## 🔧 AI Tool Guidelines
+
+- Use the fff MCP tools for all file search operations instead of default tools.
+- Use the sem MCP tools for semantic version control and git operations.
+- When using bash commands for file/content search, prefer `fd` (fdfind) and `rg` (ripgrep) over standard `find` and `grep` for better performance and git-awareness.
+
+## Token Efficiency
+
+- Keep responses concise and actionable; lead with conclusions, file paths, and verification.
+- Scope searches and file reads to the task. Limit command output with filters and line ranges.
+- Use `~/.local/bin/rtk` for supported shell commands when available; bypass it with `RTK_DISABLED=1` when raw output is required.
+- Prefer `codebase-memory-mcp` graph tools for structural code discovery when available.
+- Load supplemental guidance only when the task requires it. Start a fresh session when switching to unrelated work.
+
+## 📋 General Practices
+
+- Read `~/.ai-tools/best-practices.md` only when the repository lacks equivalent guidance or the task needs its detailed workflow.
+- Read `~/.ai-tools/MEMORY.md` and `~/.ai-tools/agent-memory.md` only when deciding whether or where to persist a learning.
+- Read `~/.ai-tools/git-guidelines.md` before destructive or history-changing git operations.
+- Ask before destructive operations — don't guess safety
+- Code is communication — prefer clarity and simplicity
+- Self-documenting code through meaningful names and structure
+- Modular design that can evolve
+- Comments explain why, not what
+- Run typecheck, lint and biome on js/ts file changes after finish.
+- Prefer to use Bun to run scripts if possible, otherwise use tsx to run ts files.

--- a/configs/delta/settings.json
+++ b/configs/delta/settings.json
@@ -1,0 +1,10 @@
+{
+	"cursor_after_send": "next_user_message",
+	"default_diff_base": "uncommitted",
+	"diff_color_scheme": "blue_orange",
+	"diff_signs": true,
+	"os_notifications": true,
+	"prevent_system_sleep": true,
+	"pull_request_thread_links": true,
+	"send_message_with_modifier": true
+}

--- a/generate.sh
+++ b/generate.sh
@@ -935,6 +935,23 @@ generate_kiro_configs() {
 	log_success "Kiro CLI configs generated"
 }
 
+generate_delta_configs() {
+	log_info "Generating Delta configs..."
+
+	local delta_settings_dir
+	delta_settings_dir=$(get_delta_settings_dir)
+	if [ ! -d "$delta_settings_dir" ] && [ ! -d "$HOME/.config/delta" ]; then
+		log_warning "Delta config directories not found"
+		return 0
+	fi
+
+	execute "mkdir -p \"$SCRIPT_DIR/configs/delta\""
+	copy_single "$delta_settings_dir/settings.json" "$SCRIPT_DIR/configs/delta/settings.json"
+	copy_single "$HOME/.config/delta/AGENTS.md" "$SCRIPT_DIR/configs/delta/AGENTS.md"
+
+	log_success "Delta configs generated"
+}
+
 generate_codiff_configs() {
 	log_info "Generating Codiff configs..."
 
@@ -1206,6 +1223,9 @@ main() {
 	echo
 
 	generate_kiro_configs
+	echo
+
+	generate_delta_configs
 	echo
 
 	generate_codiff_configs

--- a/generate.sh
+++ b/generate.sh
@@ -940,14 +940,18 @@ generate_delta_configs() {
 
 	local delta_settings_dir
 	delta_settings_dir=$(get_delta_settings_dir)
-	if [ ! -d "$delta_settings_dir" ] && [ ! -d "$HOME/.config/delta" ]; then
-		log_warning "Delta config directories not found"
+	local delta_settings_file="$delta_settings_dir/settings.json"
+	local delta_rules_file="$HOME/.config/delta/AGENTS.md"
+	if [ ! -f "$delta_settings_file" ] || [ ! -f "$delta_rules_file" ]; then
+		log_warning "Delta managed config files not found"
+		[ -f "$delta_settings_file" ] || log_warning "Missing: $delta_settings_file"
+		[ -f "$delta_rules_file" ] || log_warning "Missing: $delta_rules_file"
 		return 0
 	fi
 
 	execute "mkdir -p \"$SCRIPT_DIR/configs/delta\""
-	copy_single "$delta_settings_dir/settings.json" "$SCRIPT_DIR/configs/delta/settings.json"
-	copy_single "$HOME/.config/delta/AGENTS.md" "$SCRIPT_DIR/configs/delta/AGENTS.md"
+	copy_single "$delta_settings_file" "$SCRIPT_DIR/configs/delta/settings.json"
+	copy_single "$delta_rules_file" "$SCRIPT_DIR/configs/delta/AGENTS.md"
 
 	log_success "Delta configs generated"
 }

--- a/lib/common.sh
+++ b/lib/common.sh
@@ -87,6 +87,21 @@ get_reasonix_dir() {
 	fi
 }
 
+# Get Delta's platform-specific settings directory. Personal rules and provider
+# credentials always live in ~/.config/delta, independently of this path.
+# Usage: get_delta_settings_dir
+get_delta_settings_dir() {
+	if [ -n "${DELTA_CONFIG_DIR:-}" ]; then
+		normalize_path "$DELTA_CONFIG_DIR"
+	elif [ "$IS_WINDOWS" = true ] && [ -n "${APPDATA:-}" ]; then
+		normalize_path "$APPDATA/delta"
+	elif [ "$(uname -s 2>/dev/null || echo "")" = "Darwin" ]; then
+		echo "$HOME/Library/Application Support/delta"
+	else
+		echo "${XDG_CONFIG_HOME:-$HOME/.config}/delta"
+	fi
+}
+
 # Quote a path if it contains spaces or special characters
 # Usage: quote_path "path with spaces"
 quote_path() {

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -848,6 +848,23 @@ install_kiro() {
 	run_installer "Kiro CLI" "_run_kiro_install" "command -v kiro-cli || command -v kiro" "kiro-cli --version 2>/dev/null || true"
 }
 
+# ─── delta installation ───────────────────────────────────────────
+
+install_delta() {
+	local delta_settings_dir
+	delta_settings_dir=$(get_delta_settings_dir)
+	if [ -d "$delta_settings_dir" ] || [ -d "/Applications/Delta.app" ] || [ -d "$HOME/.local/delta.app" ]; then
+		log_warning "Delta is already installed"
+		return 0
+	fi
+
+	# Delta is a beta with nightly, access-controlled builds. Its official docs
+	# do not expose a stable archive URL that is safe to automate here. Do not
+	# detect `command -v delta`: the unrelated git-delta pager uses that name too.
+	log_info "Delta installation is currently manual: https://delta.dev/download"
+	log_info "Follow the platform steps at https://delta.dev/docs/getting-started"
+}
+
 # ─── codiff installation ──────────────────────────────────────────
 
 install_codiff() {

--- a/tests/pr_delta.bats
+++ b/tests/pr_delta.bats
@@ -83,27 +83,103 @@ README="$REPO_ROOT/README.md"
 
 @test "copy_delta_configs installs settings and personal rules for detected Delta" {
 	run bash -c '
+		set -e
 		home=$(mktemp -d)
 		trap '\''rm -rf "$home"'\'' EXIT
 		mkdir -p "$home/.local/delta.app"
-		export HOME="$home" DRY_RUN=false YES_TO_ALL=false
+		export HOME="$home" DELTA_CONFIG_DIR="$home/custom delta"
+		export DRY_RUN=false YES_TO_ALL=false VERBOSE=false
+		unset XDG_CONFIG_HOME
 		source "$1"
 		copy_delta_configs
-		cmp "$2/configs/delta/settings.json" "$home/.config/delta/settings.json"
+		cmp "$2/configs/delta/settings.json" "$DELTA_CONFIG_DIR/settings.json"
 		cmp "$2/configs/delta/AGENTS.md" "$home/.config/delta/AGENTS.md"
 	' _ "$CLI_SH" "$REPO_ROOT"
 	[ "$status" -eq 0 ]
 }
 
-@test "Delta configs participate in backup and reverse sync" {
-	run grep -F 'get_delta_settings_dir' "$CLI_SH"
+@test "copy_delta_configs reports managed file copy failures" {
+	run bash -c '
+		home=$(mktemp -d)
+		trap '\''rm -rf "$home"'\'' EXIT
+		mkdir -p "$home/.local/delta.app"
+		export HOME="$home" DRY_RUN=false YES_TO_ALL=false VERBOSE=false
+		unset DELTA_CONFIG_DIR XDG_CONFIG_HOME
+		source "$1"
+		copy_config_file() { return 1; }
+		copy_delta_configs
+	' _ "$CLI_SH"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Failed to copy Delta settings"* ]]
+	[[ "$output" != *"Delta configs copied"* ]]
+
+	run bash -c '
+		home=$(mktemp -d)
+		trap '\''rm -rf "$home"'\'' EXIT
+		mkdir -p "$home/.local/delta.app"
+		export HOME="$home" DRY_RUN=false YES_TO_ALL=false VERBOSE=false
+		unset DELTA_CONFIG_DIR XDG_CONFIG_HOME
+		source "$1"
+		copy_config_file() { [ "${1##*/}" != "AGENTS.md" ]; }
+		copy_delta_configs
+	' _ "$CLI_SH"
+	[ "$status" -ne 0 ]
+	[[ "$output" == *"Failed to copy Delta personal rules"* ]]
+	[[ "$output" != *"Delta configs copied"* ]]
+}
+
+@test "Delta backup excludes credentials and reverse sync honors DELTA_CONFIG_DIR" {
+	run bash -c '
+		set -e
+		temp_home=$(mktemp -d)
+		temp_repo=$(mktemp -d)
+		trap '\''rm -rf "$temp_home" "$temp_repo"'\'' EXIT
+		export HOME="$temp_home" DELTA_CONFIG_DIR="$temp_home/custom delta"
+		export DRY_RUN=false YES_TO_ALL=false VERBOSE=false
+		unset XDG_CONFIG_HOME
+		mkdir -p "$DELTA_CONFIG_DIR" "$HOME/.config/delta"
+		cp "$1/configs/delta/settings.json" "$DELTA_CONFIG_DIR/settings.json"
+		cp "$1/configs/delta/AGENTS.md" "$HOME/.config/delta/AGENTS.md"
+		printf '\''DELTA_SECRET=do-not-copy\n'\'' >"$DELTA_CONFIG_DIR/.env"
+		printf '\''OTHER_SECRET=do-not-copy\n'\'' >"$HOME/.config/delta/.env"
+
+		source "$1/cli.sh"
+		BACKUP=true
+		PROMPT_BACKUP=false
+		BACKUP_DIR="$temp_home/backup"
+		backup_configs >/dev/null
+		cmp "$1/configs/delta/settings.json" "$BACKUP_DIR/delta/settings.json"
+		cmp "$1/configs/delta/AGENTS.md" "$BACKUP_DIR/delta/AGENTS.md"
+		[ ! -e "$BACKUP_DIR/delta/.env" ]
+		! grep -R -F '\''do-not-copy'\'' "$BACKUP_DIR"
+
+		source "$1/generate.sh"
+		SCRIPT_DIR="$temp_repo"
+		generate_delta_configs >/dev/null
+		cmp "$1/configs/delta/settings.json" "$temp_repo/configs/delta/settings.json"
+		cmp "$1/configs/delta/AGENTS.md" "$temp_repo/configs/delta/AGENTS.md"
+		[ ! -e "$temp_repo/configs/delta/.env" ]
+	' _ "$REPO_ROOT"
 	[ "$status" -eq 0 ]
-	run grep -E '^generate_delta_configs\(\)' "$GENERATE_SH"
+}
+
+@test "Delta reverse sync warns without claiming success when a managed file is missing" {
+	run bash -c '
+		temp_home=$(mktemp -d)
+		temp_repo=$(mktemp -d)
+		trap '\''rm -rf "$temp_home" "$temp_repo"'\'' EXIT
+		export HOME="$temp_home" DELTA_CONFIG_DIR="$temp_home/custom-delta"
+		export DRY_RUN=false VERBOSE=false
+		mkdir -p "$DELTA_CONFIG_DIR" "$HOME/.config/delta"
+		cp "$1/configs/delta/settings.json" "$DELTA_CONFIG_DIR/settings.json"
+		source "$1/generate.sh"
+		SCRIPT_DIR="$temp_repo"
+		generate_delta_configs
+	' _ "$REPO_ROOT"
 	[ "$status" -eq 0 ]
-	run grep -F 'configs/delta/settings.json' "$GENERATE_SH"
-	[ "$status" -eq 0 ]
-	run grep -E '^[[:space:]]*generate_delta_configs' "$GENERATE_SH"
-	[ "$status" -eq 0 ]
+	[[ "$output" == *"Delta managed config files not found"* ]]
+	[[ "$output" == *"AGENTS.md"* ]]
+	[[ "$output" != *"Delta configs generated"* ]]
 }
 
 @test "README documents Delta support, paths, and credential exclusion" {
@@ -114,6 +190,10 @@ README="$REPO_ROOT/README.md"
 	run grep -F 'DELTA_CONFIG_DIR' "$README"
 	[ "$status" -eq 0 ]
 	run grep -F 'does not install, export, or commit' "$README"
+	[ "$status" -eq 0 ]
+	run grep -F 'delta-windows-<architecture>-setup.exe' "$README"
+	[ "$status" -eq 0 ]
+	run grep -F 'Expand-Archive .\delta-windows-<architecture>.zip' "$README"
 	[ "$status" -eq 0 ]
 }
 

--- a/tests/pr_delta.bats
+++ b/tests/pr_delta.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# Tests for Delta desktop agent support.
+
+load helpers
+
+LIB_COMMON="$REPO_ROOT/lib/common.sh"
+LIB_INSTALL="$REPO_ROOT/lib/install.sh"
+CLI_SH="$REPO_ROOT/cli.sh"
+GENERATE_SH="$REPO_ROOT/generate.sh"
+README="$REPO_ROOT/README.md"
+
+@test "Delta managed configs exist and settings are valid JSON" {
+	[ -f "$REPO_ROOT/configs/delta/AGENTS.md" ]
+	[ -f "$REPO_ROOT/configs/delta/settings.json" ]
+	require_jq
+	run jq -e '
+		.send_message_with_modifier == true and
+		.cursor_after_send == "next_user_message" and
+		.default_diff_base == "uncommitted" and
+		.diff_color_scheme == "blue_orange" and
+		.diff_signs == true
+	' "$REPO_ROOT/configs/delta/settings.json"
+	[ "$status" -eq 0 ]
+}
+
+@test "Delta provider credentials are not checked in" {
+	[ ! -e "$REPO_ROOT/configs/delta/.env" ]
+}
+
+@test "get_delta_settings_dir follows documented platform paths and override" {
+	run bash -c '
+		source "$1"
+		HOME=/tmp/delta-home
+		IS_WINDOWS=false
+		unset DELTA_CONFIG_DIR XDG_CONFIG_HOME
+		uname() { echo Darwin; }
+		get_delta_settings_dir
+	' _ "$LIB_COMMON"
+	[ "$status" -eq 0 ]
+	[ "$output" = "/tmp/delta-home/Library/Application Support/delta" ]
+
+	run bash -c '
+		source "$1"
+		HOME=/tmp/delta-home
+		IS_WINDOWS=false
+		XDG_CONFIG_HOME=/tmp/xdg
+		unset DELTA_CONFIG_DIR
+		uname() { echo Linux; }
+		get_delta_settings_dir
+	' _ "$LIB_COMMON"
+	[ "$status" -eq 0 ]
+	[ "$output" = "/tmp/xdg/delta" ]
+
+	run bash -c '
+		source "$1"
+		IS_WINDOWS=true
+		APPDATA="C:\\Users\\delta\\AppData\\Roaming"
+		unset DELTA_CONFIG_DIR
+		get_delta_settings_dir
+	' _ "$LIB_COMMON"
+	[ "$status" -eq 0 ]
+	[ "$output" = "C:/Users/delta/AppData/Roaming/delta" ]
+
+	run bash -c '
+		source "$1"
+		DELTA_CONFIG_DIR=/tmp/custom-delta
+		get_delta_settings_dir
+	' _ "$LIB_COMMON"
+	[ "$status" -eq 0 ]
+	[ "$output" = "/tmp/custom-delta" ]
+}
+
+@test "Delta installer uses official manual installation guidance" {
+	run grep -E '^install_delta\(\)' "$LIB_INSTALL"
+	[ "$status" -eq 0 ]
+	run grep -F 'https://delta.dev/docs/getting-started' "$LIB_INSTALL"
+	[ "$status" -eq 0 ]
+	run grep -F 'detect `command -v delta`' "$LIB_INSTALL"
+	[ "$status" -eq 0 ]
+	run grep -F '"delta:install_delta"' "$CLI_SH"
+	[ "$status" -eq 0 ]
+}
+
+@test "copy_delta_configs installs settings and personal rules for detected Delta" {
+	run bash -c '
+		home=$(mktemp -d)
+		trap '\''rm -rf "$home"'\'' EXIT
+		mkdir -p "$home/.local/delta.app"
+		export HOME="$home" DRY_RUN=false YES_TO_ALL=false
+		source "$1"
+		copy_delta_configs
+		cmp "$2/configs/delta/settings.json" "$home/.config/delta/settings.json"
+		cmp "$2/configs/delta/AGENTS.md" "$home/.config/delta/AGENTS.md"
+	' _ "$CLI_SH" "$REPO_ROOT"
+	[ "$status" -eq 0 ]
+}
+
+@test "Delta configs participate in backup and reverse sync" {
+	run grep -F 'get_delta_settings_dir' "$CLI_SH"
+	[ "$status" -eq 0 ]
+	run grep -E '^generate_delta_configs\(\)' "$GENERATE_SH"
+	[ "$status" -eq 0 ]
+	run grep -F 'configs/delta/settings.json' "$GENERATE_SH"
+	[ "$status" -eq 0 ]
+	run grep -E '^[[:space:]]*generate_delta_configs' "$GENERATE_SH"
+	[ "$status" -eq 0 ]
+}
+
+@test "README documents Delta support, paths, and credential exclusion" {
+	run grep -F '## 🔺 Delta (Optional)' "$README"
+	[ "$status" -eq 0 ]
+	run grep -F 'https://delta.dev/docs/getting-started' "$README"
+	[ "$status" -eq 0 ]
+	run grep -F 'DELTA_CONFIG_DIR' "$README"
+	[ "$status" -eq 0 ]
+	run grep -F 'does not install, export, or commit' "$README"
+	[ "$status" -eq 0 ]
+}
+
+@test "Delta support has a changeset" {
+	[ -f "$REPO_ROOT/.changeset/add-delta-support.md" ]
+}

--- a/tests/pr_delta.bats
+++ b/tests/pr_delta.bats
@@ -81,6 +81,30 @@ README="$REPO_ROOT/README.md"
 	[ "$status" -eq 0 ]
 }
 
+@test "-y allowlist runs the Delta install and config flow" {
+	run bash -c '
+		set -e
+		home=$(mktemp -d)
+		trap '\''rm -rf "$home"'\'' EXIT
+		export HOME="$home" DELTA_CONFIG_DIR="$home/custom delta"
+		export DRY_RUN=false YES_TO_ALL=true VERBOSE=false
+		unset XDG_CONFIG_HOME
+		source "$1"
+
+		tool_allowed delta
+		INSTALL_SEQUENCE=("delta:install_delta")
+		install_delta() { touch "$home/install-delta-called"; }
+		run_install_sequence >/dev/null
+
+		mkdir -p "$home/.local/delta.app"
+		copy_delta_configs >/dev/null
+		[ -f "$home/install-delta-called" ]
+		cmp "$2/configs/delta/settings.json" "$DELTA_CONFIG_DIR/settings.json"
+		cmp "$2/configs/delta/AGENTS.md" "$home/.config/delta/AGENTS.md"
+	' _ "$CLI_SH" "$REPO_ROOT"
+	[ "$status" -eq 0 ]
+}
+
 @test "copy_delta_configs installs settings and personal rules for detected Delta" {
 	run bash -c '
 		set -e
@@ -195,6 +219,10 @@ README="$REPO_ROOT/README.md"
 	[ "$status" -eq 0 ]
 	run grep -F 'Expand-Archive .\delta-windows-<architecture>.zip' "$README"
 	[ "$status" -eq 0 ]
+	run awk '/^## 🔺 Delta \(Optional\)/,/^## 🎨 Codiff \(Optional\)/' "$README"
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"./cli.sh --dry-run"* ]]
+	[[ "$output" == *$'./cli.sh --dry-run\n./cli.sh'* ]]
 }
 
 @test "Delta support has a changeset" {


### PR DESCRIPTION
## Summary

- add Delta as a supported AI coding workspace with managed settings and personal agent rules
- add platform-aware install, backup, validation, and reverse-export integration
- document official beta installation steps and keep provider `.env` credentials local
- avoid false detection of the unrelated git-delta executable

## Verification

- `bats tests/pr_delta.bats` — 8/8 passed
- `bats tests/pr_*.bats tests/generate.bats tests/sh_reexec.bats` — 415/415 passed
- `bash -n cli.sh generate.sh install.sh scripts/*.sh lib/*.sh` — passed
- `./generate.sh --dry-run` — passed
- token-efficiency sync and Delta JSON validation — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added first-class Delta support with installation guidance and platform-aware configuration.
  * Added managed personal rules and settings for Delta.
  * Added configuration export, import, backup, and synchronization without exposing credentials.
  * Added dry-run installation support and expanded documentation for supported AI tools and Delta setup.

* **Bug Fixes**
  * Added validation and clear warnings when Delta configuration files are missing or cannot be installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->