### PR TITLE
docs(guidance): make engineering work more checkable

### DIFF
--- a/configs/amp/plugins/my-ai-tools-skills/skills/accountable-engineering/SKILL.md
+++ b/configs/amp/plugins/my-ai-tools-skills/skills/accountable-engineering/SKILL.md
@@ -19,14 +19,16 @@ accepting generated decisions that nobody can independently explain.
 ### 1. Define behavior and constraints
 
 Write the expected behavior, non-goals, security boundaries, performance expectations, and verification criteria before
-editing code.
+editing code. Inspect repository evidence before asking questions. Ask only when different interpretations would change
+behavior, scope, interfaces, security, or another material outcome.
 
 **Complete when**: Each requested behavior has a checkable outcome, and every known constraint or non-goal is explicit.
 
 ### 2. Propose approach before implementation
 
 Inspect the relevant code and propose the smallest approach that fits its existing boundaries. Include data flow,
-integration points, failure handling, meaningful alternatives, and unanswered questions.
+integration points, failure handling, meaningful alternatives, and unanswered questions. For each significant step, name
+the test, command, observable behavior, or diff property that will prove it is complete.
 
 Load `blindspot-pass` for hidden gotchas, `spec-interview` when requirements can change the design, or
 `context-discovery` when the behavior spans multiple modules or tools.
@@ -45,7 +47,8 @@ explained without relying on generated code.
 ### 4. Implement in small steps
 
 Implement the smallest independently verifiable increment, then inspect its diff and run its targeted check before
-continuing.
+continuing. Account for every changed hunk as either required work or cleanup made necessary by that work. Remove
+unrelated formatting, renaming, refactoring, and commentary changes.
 
 Load `tdd` when behavior can be expressed as a failing test. Load `implementation-logger` when repository reality
 forces a material deviation from the approved approach.

--- a/configs/best-practices.md
+++ b/configs/best-practices.md
@@ -78,7 +78,15 @@ Make big changes through small, safe steps. Code is communication between humans
 
 **Self-documenting**: Meaningful names and clear structure beat comments. Comments explain why, not what.
 
-**Keep changes focused**: Change only what the task requires. Do not reformat, rename, or annotate unrelated code.
+**Resolve material ambiguity**: Inspect repository evidence first. Ask only when different interpretations would change
+behavior, scope, interfaces, security, or other important outcomes.
+
+**Keep changes focused**: Change only what the task requires. Before completion, inspect the diff and account for every
+hunk as either required work or cleanup made necessary by that work. Remove unrelated formatting, renaming, refactoring,
+and commentary changes.
+
+**Make progress checkable**: For each significant plan step, name the test, command, observable behavior, or diff property
+that proves it is complete. Scale the evidence to the risk; not every change needs a new test.
 
 **Name meaningful values**: Extract recurring values and values defined by protocols or business rules into descriptive
 constants or enums. Keep obvious one-off values inline when a name would add noise.

--- a/skills/accountable-engineering/SKILL.md
+++ b/skills/accountable-engineering/SKILL.md
@@ -19,14 +19,16 @@ accepting generated decisions that nobody can independently explain.
 ### 1. Define behavior and constraints
 
 Write the expected behavior, non-goals, security boundaries, performance expectations, and verification criteria before
-editing code.
+editing code. Inspect repository evidence before asking questions. Ask only when different interpretations would change
+behavior, scope, interfaces, security, or another material outcome.
 
 **Complete when**: Each requested behavior has a checkable outcome, and every known constraint or non-goal is explicit.
 
 ### 2. Propose approach before implementation
 
 Inspect the relevant code and propose the smallest approach that fits its existing boundaries. Include data flow,
-integration points, failure handling, meaningful alternatives, and unanswered questions.
+integration points, failure handling, meaningful alternatives, and unanswered questions. For each significant step, name
+the test, command, observable behavior, or diff property that will prove it is complete.
 
 Load `blindspot-pass` for hidden gotchas, `spec-interview` when requirements can change the design, or
 `context-discovery` when the behavior spans multiple modules or tools.
@@ -45,7 +47,8 @@ explained without relying on generated code.
 ### 4. Implement in small steps
 
 Implement the smallest independently verifiable increment, then inspect its diff and run its targeted check before
-continuing.
+continuing. Account for every changed hunk as either required work or cleanup made necessary by that work. Remove
+unrelated formatting, renaming, refactoring, and commentary changes.
 
 Load `tdd` when behavior can be expressed as a failing test. Load `implementation-logger` when repository reality
 forces a material deviation from the approved approach.

--- a/tests/pr_accountable_engineering.bats
+++ b/tests/pr_accountable_engineering.bats
@@ -15,6 +15,15 @@ setup() {
 	[ "$output" -eq 8 ]
 }
 
+@test "accountable workflow requires material questions and checkable focused changes" {
+	run grep -F 'Ask only when different interpretations would change' "$SKILL"
+	[ "$status" -eq 0 ]
+	run grep -F 'For each significant step, name' "$SKILL"
+	[ "$status" -eq 0 ]
+	run grep -F 'Account for every changed hunk as either required work or cleanup made necessary by that work.' "$SKILL"
+	[ "$status" -eq 0 ]
+}
+
 @test "accountable engineering references installed paths" {
 	run grep -F '@~/.agents/skills/accountable-engineering/SKILL.md' "$REPO_ROOT/configs/best-practices.md"
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

This compares `multica-ai/andrej-karpathy-skills` with the guidance and skill system already present in `my-ai-tools`, then adopts only the small set of practices that close real gaps.

## Lessons adopted

- **Resolve only material ambiguity:** inspect repository evidence first, and ask when competing interpretations would change behavior, scope, interfaces, security, or another important outcome.
- **Make plans falsifiable:** attach a test, command, observable behavior, or diff property to each significant step.
- **Keep diffs request-traceable:** account for every changed hunk as required work or change-induced cleanup, and remove unrelated edits.
- **Scale verification to risk:** retain the useful goal-driven principle without requiring a new test for every trivial or documentation-only change.

These rules extend the existing `best-practices.md` and `accountable-engineering` workflow instead of adding another overlapping skill.

## Lessons intentionally not adopted

- **No Karpathy-branded skill or persona:** the operational rules matter more than attribution, and an additional skill would overlap with `accountable-engineering`.
- **No duplicated Claude/Cursor/marketplace wrappers:** this repository already has canonical cross-tool sources, installers, an Amp skill bundle, and parity tests. Copying the source repository's manual synchronization model would increase drift risk.
- **No absolute “ask whenever uncertain” rule:** agents should resolve normal implementation details from repository evidence and interrupt only for decisions that materially change the outcome.
- **No absolute bans on single-use abstractions or “impossible” error handling:** existing architecture, trust boundaries, public APIs, concurrency, and test seams can justify them.
- **No mandatory test-first ceremony:** reproducible bugs benefit from a failing regression test, but documentation, generated config, and already-covered behavior need proportionate evidence instead.
- **No copied example catalog:** its examples teach useful reasoning patterns, but several are illustrative rather than production-grade and would duplicate this repository's focused skills.

## Files changed

- `configs/best-practices.md` — adds material-ambiguity, diff-traceability, and checkable-plan guidance.
- `skills/accountable-engineering/SKILL.md` — integrates the practices into the existing checkpoint workflow.
- `configs/amp/plugins/my-ai-tools-skills/skills/accountable-engineering/SKILL.md` — keeps the packaged Amp skill identical to the canonical skill.
- `tests/pr_accountable_engineering.bats` — asserts the new guidance remains part of the workflow.

## Verification

- `bash -n cli.sh generate.sh install.sh scripts/*.sh` — passed.
- `bats tests/pr_accountable_engineering.bats tests/pr_amp_skills_plugin.bats` — 8/8 passed.
- `git diff --check` — passed.
- `./cli.sh --dry-run` — remained side-effect-free and reached prerequisite checks; exits nonzero in this orb because Rust/cargo is absent and dry-run does not install it.
- `bunx biome check <changed files>` — not applicable; the repository's Biome configuration ignores Markdown and Bats files.
- `bats tests/pr_*.bats tests/generate.bats tests/sh_reexec.bats` — 433/440 passed. The 7 failures are existing `tests/pr_ai_launcher.bats` assertions that still expect Reasonix commands after current `main` migrated those templates to OpenCode 2; this branch does not change either affected file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated engineering guidance to resolve material ambiguity using repository evidence before asking questions.
  - Added requirements to define verification methods for significant work and account for every changed section.
  - Clarified that unrelated formatting, renaming, refactoring, and commentary should be removed from focused changes.
  - Applied these guidelines consistently across the relevant best-practices and engineering workflow documentation.

- **Tests**
  - Added automated coverage to verify the accountable-engineering guidance includes the new requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->