### PR TITLE
feat: add Meta Muse Code support

### DIFF
--- a/.changeset/add-muse-code-support.md
+++ b/.changeset/add-muse-code-support.md
@@ -1,0 +1,7 @@
+---
+"my-ai-tools": minor
+---
+
+Add Meta Muse Code as a first-class supported coding agent with its official
+installer, managed MCP settings, bidirectional config sync, and documentation
+for the newly announced CLI features and developer-preview TypeScript SDK.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub license](https://img.shields.io/github/license/jellydn/my-ai-tools)](https://github.com/jellydn/my-ai-tools/blob/main/LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/jellydn/my-ai-tools/pulls)
 
-> **Comprehensive configuration management for AI coding tools** - Replicate my complete setup for Claude Code, OpenCode, fx, Amp, Kilo CLI, Codex, Devin CLI, Kimi Code, Gemini CLI, Antigravity CLI, Pi, Oh My Pi, GitHub Copilot CLI, Cursor Agent CLI, Factory Droid, Cline, Grok CLI, MiMo-Code, Qoder CLI, DeepSeek Harness, Kiro CLI, Delta, Hunk, Codiff, ctx, Open Code Review, CCS, and Reasonix with custom configurations, MCP servers, skills, plugins, and commands.
+> **Comprehensive configuration management for AI coding tools** - Replicate my complete setup for Claude Code, OpenCode, fx, Muse Code, Amp, Kilo CLI, Codex, Devin CLI, Kimi Code, Gemini CLI, Antigravity CLI, Pi, Oh My Pi, GitHub Copilot CLI, Cursor Agent CLI, Factory Droid, Cline, Grok CLI, MiMo-Code, Qoder CLI, DeepSeek Harness, Kiro CLI, Delta, Hunk, Codiff, ctx, Open Code Review, CCS, and Reasonix with custom configurations, MCP servers, skills, plugins, and commands.
 
 📖 **[View Documentation Website](https://ai-tools.itman.fyi)** - Interactive landing page with full documentation and search.
 
@@ -12,7 +12,7 @@
 
 - 🚀 **One-line installer** - Get started in seconds
 - 🔄 **Bidirectional sync** - Install configs or export your current setup
-- 🤖 **Multiple AI tools** - Claude Code, OpenCode, fx, Amp, CCS, Devin, Kimi Code, Gemini, Antigravity, Grok, MiMo-Code, Qoder CLI, DeepSeek Harness, Kiro CLI, Delta, Hunk, Codiff, ctx, Open Code Review, Reasonix, and more
+- 🤖 **Multiple AI tools** - Claude Code, OpenCode, fx, Muse Code, Amp, CCS, Devin, Kimi Code, Gemini, Antigravity, Grok, MiMo-Code, Qoder CLI, DeepSeek Harness, Kiro CLI, Delta, Hunk, Codiff, ctx, Open Code Review, Reasonix, and more
 - 🔌 **MCP Server integration** - Context7, Sequential-thinking, qmd, codebase-memory-mcp, agentmemory, sem, ctx
 - 🎯 **Custom agents & skills** - Pre-configured for maximum productivity
 - 🤝 **Agent Teams** - Coordinate specialized agents for complex workflows (code review, testing, docs)
@@ -153,6 +153,7 @@ The lead hands off exact skill paths plus `OBJECTIVE / FILES / INTERFACES / CONS
 | **Kimi Code**   | context7, sequential-thinking, qmd, codebase-memory-mcp, agentmemory, fff, logpilot, sem, ctx                              | Skills, MCP servers, and hooks via `~/.kimi-code/`                                                                                                                                                                                             |
 | **Pi**          | context7, sequential-thinking, qmd, codebase-memory-mcp, fff, react-grab-mcp, agentmemory, sem, ctx                        | Packages (pi-extension, pi-subagents, autoresearch, fff, mcp-adapter, simplify, rpiv-todo, btw, code-previews, codex-goal, commandcode-provider, pi-web-access, footer, tps-meter, pi-qwencloud-provider, pi-cursor-sdk) |
 | **Oh My Pi**  | Pi-compatible layout; MCP servers via `~/.omp/agent/mcp.json` when present                                                  | Pi fork (`@oh-my-pi/pi-coding-agent`); configs managed under `configs/omp/`                                                                                                                                          |
+| **Muse Code**   | context7, sequential-thinking, qmd, codebase-memory-mcp, agentmemory, fff, react-grab-mcp, logpilot, sem, ctx              | Workflows, session messaging, rewind, shared `~/.agents/skills`, developer-preview SDK                                                                                                                                                         |
 | **Amp**         | context7, sequential-thinking, qmd, codebase-memory-mcp, agentmemory, fff, react-grab-mcp, logpilot, sem, ctx              | Agent modes: fusion, glm-5.2, grok45, inkling, cursor-composer-2.5; plannotator; orca-agent-status                                                                                                                                             |
 | **Gemini**      | context7, sequential-thinking, qmd, codebase-memory-mcp, agentmemory, fff, react-grab-mcp, logpilot, sem, ctx              | Deprecated for Google One/unpaid tiers; migrate to Antigravity                                                                                                                                                                                 |
 | **Antigravity** | context7, sequential-thinking, qmd, codebase-memory-mcp, agentmemory, fff, react-grab-mcp, logpilot, sem, ctx (via plugin) | my-ai-tools-gemini-migration                                                                                                                                                                                                                   |
@@ -263,7 +264,7 @@ cd my-ai-tools
 - `--dry-run` - Preview changes without making them
 - `--backup` - Backup existing configs before installing
 - `--no-backup` - Skip backup prompt
-- `-y` / `--yes` - Non-interactive mode; only installs/configures your active tool set (amp, codex, ctx, cursor, fx, kilo, opencode, open_code_review, pi, omp, antigravity, ai-switcher, claude, reasonix). Shared infra (plugins, skills, global tools) still installed. Auto-activated in CI/piped input.
+- `-y` / `--yes` - Non-interactive mode; only installs/configures your active tool set (amp, codex, ctx, cursor, fx, kilo, muse, opencode, open_code_review, pi, omp, antigravity, ai-switcher, claude, reasonix). Shared infra (plugins, skills, global tools) still installed. Auto-activated in CI/piped input.
 - `--migrate-gemini` - One-step Gemini→Antigravity CLI migration
 
 ## 🔄 Bidirectional Config Sync
@@ -299,6 +300,37 @@ fx
 ```
 
 fx discovers shared skills from `~/.agents/skills/`, so it uses this repository's universal skill installation automatically. Its MCP configuration at `~/.fx/mcp.json` and other runtime state remain private by design and are not managed by this repository.
+
+## 🎼 Muse Code (Optional)
+
+[Muse Code](https://dev.meta.ai/docs/muse-code) is Meta's coding agent for terminal and CI workflows, powered by Muse Spark 1.2. Meta brought it out of beta on August 31, 2026 with inter-session messaging, multi-agent workflows, safe conversation rewind, and a developer-preview SDK. [Announcement](https://developer.meta.com/ai/resources/blog/muse-code-new-plans-and-features/) | [Docs](https://dev.meta.ai/docs/muse-code) | [SDK](https://github.com/meta-models/muse-code-sdk)
+
+```bash
+# Official macOS/Linux installer
+curl -fsSL https://dev.meta.ai/install.sh | sh
+
+# Start an interactive session, or run one headless task
+muse
+muse exec "Review this repository and run its tests."
+```
+
+This repository installs [`configs/muse/settings.json`](configs/muse/settings.json) to `~/.config/muse/settings.json`. The file uses Muse's required `schema_version: 1` and configures the standard MCP tool set as optional servers, so an unavailable local tool does not abort Muse. `./generate.sh` exports only this managed settings file; credentials, sessions, event logs, and other local runtime state stay outside the repository.
+
+Muse reads project instructions from `AGENTS.md` and discovers this repository's universal skills directly from `~/.agents/skills`. The announced CLI features include:
+
+- **Session messaging** between local Muse processes over a Unix socket
+- **Workflows** for parallel or staged agent teams, monitored with `/workflows`
+- **Rewind** to a safe earlier conversation point by pressing `Esc` twice
+
+### Muse Code SDK (Developer Preview)
+
+The SDK is a per-project TypeScript dependency, not another global CLI. It requires Node.js 20+ and a separately installed `muse` binary, which it launches as a local `muse serve` host over the Muse Session Protocol:
+
+```bash
+npm install @muse-code/sdk
+```
+
+The pre-1.0 SDK supports starting and resuming sessions, streaming responses, handling permission requests, and controlling the local Muse host. Minor releases can contain breaking changes during the developer preview.
 
 ## 🤖 Chat with the repo
 
@@ -3345,6 +3377,7 @@ ctx mcp serve
 The ctx MCP server is configured for all supported AI tools via this repo's config files and the central MCP registry (`configs/mcp-registry.json`):
 
 - **Claude Code**, **Cursor**, **Cline**, **Factory Droid**, **Kimi Code**, **CommandCode**, **Kiro**, **Copilot**, **Qoder CLI**, **Pi**, **Antigravity** — registered in tool-specific `mcpServers` JSON config
+- **Muse Code** — registered in the native `mcp_servers` settings block with optional stdio transports
 - **DeepSeek Harness** — registered as `@deepseek-ai/dsh-mcp-client` entries in `cordis.patch.yml`
 - **OpenCode**, **Kilo** — registered in `mcp.ctx` (array-command format)
 - **Codex**, **Grok** — registered in TOML `[mcp_servers.ctx]` format

--- a/cli.sh
+++ b/cli.sh
@@ -13,7 +13,7 @@ source "$SCRIPT_DIR/lib/install.sh"
 # Core tools installed/configured when -y (YES_TO_ALL) is active.
 # This is your personal active tool set. When YES_TO_ALL is false
 # (interactive mode), tool_allowed returns true for everything.
-TOOL_ALLOWLIST_YES=(amp codex ctx cursor deepseek_harness delta fx kilo opencode open_code_review pi omp antigravity ai-switcher claude reasonix)
+TOOL_ALLOWLIST_YES=(amp codex ctx cursor deepseek_harness delta fx kilo muse opencode open_code_review pi omp antigravity ai-switcher claude reasonix)
 
 tool_allowed() {
 	local name="$1"
@@ -36,6 +36,7 @@ INSTALL_SEQUENCE=(
 	"opencode:install_opencode2"
 	"opencode:install_open_cursor"
 	"fx:install_fx"
+	"muse:install_muse"
 	"amp:install_amp"
 	"always:install_global_tools"
 	"ccs:install_ccs"
@@ -334,6 +335,7 @@ backup_configs() {
 		copy_config_dir "$HOME/.config/opencode" "$BACKUP_DIR" "opencode"
 		copy_config_dir "$HOME/.config/amp" "$BACKUP_DIR" "amp"
 		copy_config_file "$HOME/.fx/AGENTS.md" "$BACKUP_DIR/fx" || true
+		copy_config_file "$HOME/.config/muse/settings.json" "$BACKUP_DIR/muse" || true
 		copy_config_dir "$HOME/.codex" "$BACKUP_DIR" "codex"
 		copy_config_dir "$HOME/.kimi-code" "$BACKUP_DIR" "kimi-code"
 		copy_config_dir "$HOME/.gemini" "$BACKUP_DIR" "gemini"
@@ -513,6 +515,11 @@ copy_configurations() {
 	else
 		log_info "Skipping fx config install (not in -y allowlist)"
 	fi
+	if tool_allowed "muse"; then
+		copy_muse_configs
+	else
+		log_info "Skipping muse config install (not in -y allowlist)"
+	fi
 	if tool_allowed "amp"; then
 		copy_amp_configs
 	else
@@ -669,6 +676,7 @@ _validate_config_tool_name() {
 		*kilo/config.json*) echo "kilo" ;;
 		*reasonix/config.toml*) echo "reasonix" ;;
 		*hunk/config.toml*) echo "hunk" ;;
+		*muse/settings.json*) echo "muse" ;;
 		*deepseek-harness/*.yaml* | *deepseek-harness/*.yml*) echo "deepseek_harness" ;;
 		*delta/settings.json*) echo "delta" ;;
 		*kimi-code/*.json* | *kimi-code/*.toml*) echo "kimi_code" ;;
@@ -717,6 +725,7 @@ validate_all_configs() {
 		"$SCRIPT_DIR/configs/kilo/config.json" \
 		"$SCRIPT_DIR/configs/reasonix/config.toml" \
 		"$SCRIPT_DIR/configs/hunk/config.toml" \
+		"$SCRIPT_DIR/configs/muse/settings.json" \
 		"$SCRIPT_DIR/configs/deepseek-harness/settings.yaml" \
 		"$SCRIPT_DIR/configs/deepseek-harness/cordis.patch.yml" \
 		"$SCRIPT_DIR/configs/delta/settings.json" \
@@ -1122,6 +1131,20 @@ copy_fx_configs() {
 	execute_quoted mkdir -p "$HOME/.fx"
 	copy_config_file "$SCRIPT_DIR/configs/fx/AGENTS.md" "$HOME/.fx/" || return 1
 	log_success "fx configs copied"
+}
+
+copy_muse_configs() {
+	local muse_status
+	muse_status=$(detect_tool --detailed "muse" "$HOME/.config/muse") || muse_status="missing"
+	if [ "$muse_status" = "missing" ]; then
+		log_info "Muse Code not detected - skipping Muse Code config installation"
+		return 0
+	fi
+
+	log_info "Detected Muse Code (via $muse_status)"
+	execute_quoted mkdir -p "$HOME/.config/muse"
+	copy_config_file "$SCRIPT_DIR/configs/muse/settings.json" "$HOME/.config/muse/" || return 1
+	log_success "Muse Code configs copied"
 }
 
 copy_amp_configs() {
@@ -2750,7 +2773,7 @@ main() {
 	echo "╔══════════════════════════════════════════════════════════════════════╗"
 	echo "║                        AI Tools Setup                                ║"
 	echo "║  Claude • OpenCode • fx • Amp • CCS • Codex • Kimi Code • Gemini     ║"
-	echo "║  Antigravity • Pi • Kilo • Copilot • Cursor • Command Code           ║"
+	echo "║  Muse • Antigravity • Pi • Kilo • Copilot • Cursor • Command Code    ║"
 	echo "║  Factory Droid • Cline • Grok • MiMo-Code • herdr                    ║"
 	echo "║  Qoder CLI • DeepSeek Harness • Kiro • Delta • Codiff • Hunk         ║"
 	echo "║  Devin • ctx • Reasonix                                               ║"

--- a/cli.sh
+++ b/cli.sh
@@ -668,24 +668,24 @@ copy_configurations() {
 # Used by validate_all_configs to skip non-allowlisted tool configs.
 _validate_config_tool_name() {
 	case "$1" in
-		*amp/settings.json*) echo "amp" ;;
-		*ai-launcher/config.json*) echo "ai-switcher" ;;
-		*codex/config.json*) echo "codex" ;;
-		*gemini/settings.json*) echo "gemini" ;;
-		*antigravity-cli/settings.json*) echo "antigravity" ;;
-		*kilo/config.json*) echo "kilo" ;;
-		*reasonix/config.toml*) echo "reasonix" ;;
-		*hunk/config.toml*) echo "hunk" ;;
-		*muse/settings.json*) echo "muse" ;;
-		*deepseek-harness/*.yaml* | *deepseek-harness/*.yml*) echo "deepseek_harness" ;;
-		*delta/settings.json*) echo "delta" ;;
-		*kimi-code/*.json* | *kimi-code/*.toml*) echo "kimi_code" ;;
-		*pi/settings.json*) echo "pi" ;;
-		*omp/*.yml* | *omp/*.yaml* | *omp/*.json*) echo "omp" ;;
-		*commandcode/*.json*) echo "commandcode" ;;
-		*cline/*.json*) echo "cline" ;;
-		*factory/settings.json*) echo "factory" ;;
-		*) echo "unknown" ;;
+	*amp/settings.json*) echo "amp" ;;
+	*ai-launcher/config.json*) echo "ai-switcher" ;;
+	*codex/config.json*) echo "codex" ;;
+	*gemini/settings.json*) echo "gemini" ;;
+	*antigravity-cli/settings.json*) echo "antigravity" ;;
+	*kilo/config.json*) echo "kilo" ;;
+	*reasonix/config.toml*) echo "reasonix" ;;
+	*hunk/config.toml*) echo "hunk" ;;
+	*muse/settings.json*) echo "muse" ;;
+	*deepseek-harness/*.yaml* | *deepseek-harness/*.yml*) echo "deepseek_harness" ;;
+	*delta/settings.json*) echo "delta" ;;
+	*kimi-code/*.json* | *kimi-code/*.toml*) echo "kimi_code" ;;
+	*pi/settings.json*) echo "pi" ;;
+	*omp/*.yml* | *omp/*.yaml* | *omp/*.json*) echo "omp" ;;
+	*commandcode/*.json*) echo "commandcode" ;;
+	*cline/*.json*) echo "cline" ;;
+	*factory/settings.json*) echo "factory" ;;
+	*) echo "unknown" ;;
 	esac
 }
 
@@ -1143,7 +1143,35 @@ copy_muse_configs() {
 
 	log_info "Detected Muse Code (via $muse_status)"
 	execute_quoted mkdir -p "$HOME/.config/muse"
-	copy_config_file "$SCRIPT_DIR/configs/muse/settings.json" "$HOME/.config/muse/" || return 1
+	local muse_src="$SCRIPT_DIR/configs/muse/settings.json"
+	local muse_dest="$HOME/.config/muse/settings.json"
+	if [ -f "$muse_dest" ]; then
+		if ! command -v jq &>/dev/null; then
+			log_warning "Existing Muse settings found but jq is not installed. Install jq to merge configs, or manually update $muse_dest"
+			return 1
+		fi
+		local muse_merged
+		muse_merged=$(make_temp_file "muse-settings" "json")
+		if jq -s '
+			.[0] as $existing |
+			.[1] as $src |
+			$existing + ($src | with_entries(select(.key == "schema_version" or .key == "mcpServers" or .key == "mcp_servers")))
+			| with_entries(select(.value != null))
+		' "$muse_dest" "$muse_src" >"$muse_merged"; then
+			execute_quoted cp -p "$muse_merged" "$muse_dest" || {
+				rm -f "$muse_merged"
+				return 1
+			}
+			rm -f "$muse_merged"
+			log_success "Muse Code configs merged"
+			return 0
+		else
+			rm -f "$muse_merged"
+			log_error "Failed to merge Muse Code settings"
+			return 1
+		fi
+	fi
+	copy_config_file "$muse_src" "$HOME/.config/muse/" || return 1
 	log_success "Muse Code configs copied"
 }
 

--- a/configs/delta/settings.json
+++ b/configs/delta/settings.json
@@ -1,10 +1,41 @@
 {
-	"cursor_after_send": "next_user_message",
-	"default_diff_base": "uncommitted",
-	"diff_color_scheme": "blue_orange",
-	"diff_signs": true,
-	"os_notifications": true,
-	"prevent_system_sleep": true,
-	"pull_request_thread_links": true,
-	"send_message_with_modifier": true
+  "version": 1,
+  "portable": {
+    "appearance": "system",
+    "light_theme": "Delta One Light",
+    "dark_theme": "Delta One Dark",
+    "font_size": "default",
+    "code_font_size": "default",
+    "font_family": "Maple Mono NF",
+    "ui_font_family": "Maple UI",
+    "buffer_font_family": "Maple Mono NF",
+    "ligatures": true,
+    "send_message_with_modifier": true,
+    "send_message_with_modifier_was_enabled": true,
+    "cursor_after_send": "agent_response",
+    "model_picker": {
+      "favorites": [],
+      "hidden_models": []
+    },
+    "model_preferences": {},
+    "file_pane": {
+      "line_numbers": true,
+      "soft_wrap": false
+    },
+    "default_diff_base": "branch",
+    "subagent_concurrency": {
+      "maximum_per_parent": 4,
+      "maximum_total": 8
+    },
+    "subagent_defaults": {
+      "allow_parent_model_override": true
+    },
+    "diff_color_scheme": "green_red",
+    "diff_signs": false,
+    "pull_request_thread_links": true
+  },
+  "native": {
+    "os_notifications": true,
+    "prevent_system_sleep": true
+  }
 }

--- a/configs/muse/settings.json
+++ b/configs/muse/settings.json
@@ -1,75 +1,86 @@
 {
-	"schema_version": 1,
-	"mcp_servers": {
-		"context7": {
-			"transport": "stdio",
-			"command": "npx",
-			"args": ["-y", "@upstash/context7-mcp@3.2.5"],
-			"enabled": true,
-			"mode": "optional"
-		},
-		"sequential-thinking": {
-			"transport": "stdio",
-			"command": "npx",
-			"args": ["-y", "@modelcontextprotocol/server-sequential-thinking@2026.7.4"],
-			"enabled": true,
-			"mode": "optional"
-		},
-		"qmd": {
-			"transport": "stdio",
-			"command": "qmd",
-			"args": ["mcp"],
-			"enabled": true,
-			"mode": "optional"
-		},
-		"codebase-memory-mcp": {
-			"transport": "stdio",
-			"command": "codebase-memory-mcp",
-			"args": [],
-			"enabled": true,
-			"mode": "optional"
-		},
-		"fff": {
-			"transport": "stdio",
-			"command": "fff-mcp",
-			"args": [],
-			"enabled": true,
-			"mode": "optional"
-		},
-		"react-grab-mcp": {
-			"transport": "stdio",
-			"command": "npx",
-			"args": ["-y", "@react-grab/mcp@0.1.37", "--stdio"],
-			"enabled": true,
-			"mode": "optional"
-		},
-		"logpilot": {
-			"transport": "stdio",
-			"command": "logpilot",
-			"args": ["mcp-server"],
-			"enabled": true,
-			"mode": "optional"
-		},
-		"agentmemory": {
-			"transport": "stdio",
-			"command": "npx",
-			"args": ["-y", "@agentmemory/mcp@0.9.28"],
-			"enabled": true,
-			"mode": "optional"
-		},
-		"sem": {
-			"transport": "stdio",
-			"command": "sem-mcp",
-			"args": [],
-			"enabled": true,
-			"mode": "optional"
-		},
-		"ctx": {
-			"transport": "stdio",
-			"command": "ctx",
-			"args": ["mcp", "serve"],
-			"enabled": true,
-			"mode": "optional"
-		}
-	}
+  "schema_version": 1,
+  "tui": {
+    "theme": "kanagawa-wave",
+    "foreign_context_notice_shown": true
+  },
+  "mcpServers": {
+    "agentmemory": {
+      "mode": "optional",
+      "transport": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@agentmemory/mcp@0.9.28"
+      ]
+    },
+    "codebase-memory-mcp": {
+      "mode": "optional",
+      "transport": "stdio",
+      "command": "codebase-memory-mcp"
+    },
+    "context7": {
+      "mode": "optional",
+      "transport": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@upstash/context7-mcp@3.2.5"
+      ]
+    },
+    "ctx": {
+      "mode": "optional",
+      "transport": "stdio",
+      "command": "ctx",
+      "args": [
+        "mcp",
+        "serve"
+      ]
+    },
+    "fff": {
+      "mode": "optional",
+      "transport": "stdio",
+      "command": "fff-mcp"
+    },
+    "logpilot": {
+      "mode": "optional",
+      "transport": "stdio",
+      "command": "logpilot",
+      "args": [
+        "mcp-server"
+      ]
+    },
+    "qmd": {
+      "mode": "optional",
+      "transport": "stdio",
+      "command": "qmd",
+      "args": [
+        "mcp"
+      ]
+    },
+    "react-grab-mcp": {
+      "mode": "optional",
+      "transport": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@react-grab/mcp@0.1.37",
+        "--stdio"
+      ]
+    },
+    "sem": {
+      "mode": "optional",
+      "transport": "stdio",
+      "command": "sem-mcp"
+    },
+    "sequential-thinking": {
+      "mode": "optional",
+      "transport": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-sequential-thinking@2026.7.4"
+      ]
+    }
+  }
 }

--- a/configs/muse/settings.json
+++ b/configs/muse/settings.json
@@ -1,0 +1,75 @@
+{
+	"schema_version": 1,
+	"mcp_servers": {
+		"context7": {
+			"transport": "stdio",
+			"command": "npx",
+			"args": ["-y", "@upstash/context7-mcp@3.2.5"],
+			"enabled": true,
+			"mode": "optional"
+		},
+		"sequential-thinking": {
+			"transport": "stdio",
+			"command": "npx",
+			"args": ["-y", "@modelcontextprotocol/server-sequential-thinking@2026.7.4"],
+			"enabled": true,
+			"mode": "optional"
+		},
+		"qmd": {
+			"transport": "stdio",
+			"command": "qmd",
+			"args": ["mcp"],
+			"enabled": true,
+			"mode": "optional"
+		},
+		"codebase-memory-mcp": {
+			"transport": "stdio",
+			"command": "codebase-memory-mcp",
+			"args": [],
+			"enabled": true,
+			"mode": "optional"
+		},
+		"fff": {
+			"transport": "stdio",
+			"command": "fff-mcp",
+			"args": [],
+			"enabled": true,
+			"mode": "optional"
+		},
+		"react-grab-mcp": {
+			"transport": "stdio",
+			"command": "npx",
+			"args": ["-y", "@react-grab/mcp@0.1.37", "--stdio"],
+			"enabled": true,
+			"mode": "optional"
+		},
+		"logpilot": {
+			"transport": "stdio",
+			"command": "logpilot",
+			"args": ["mcp-server"],
+			"enabled": true,
+			"mode": "optional"
+		},
+		"agentmemory": {
+			"transport": "stdio",
+			"command": "npx",
+			"args": ["-y", "@agentmemory/mcp@0.9.28"],
+			"enabled": true,
+			"mode": "optional"
+		},
+		"sem": {
+			"transport": "stdio",
+			"command": "sem-mcp",
+			"args": [],
+			"enabled": true,
+			"mode": "optional"
+		},
+		"ctx": {
+			"transport": "stdio",
+			"command": "ctx",
+			"args": ["mcp", "serve"],
+			"enabled": true,
+			"mode": "optional"
+		}
+	}
+}

--- a/generate.sh
+++ b/generate.sh
@@ -258,6 +258,19 @@ generate_fx_configs() {
 	log_success "fx configs generated"
 }
 
+generate_muse_configs() {
+	log_info "Generating Muse Code configs..."
+
+	if [ ! -f "$HOME/.config/muse/settings.json" ]; then
+		log_warning "Muse Code config not found: $HOME/.config/muse/settings.json"
+		return 0
+	fi
+
+	execute_quoted mkdir -p "$SCRIPT_DIR/configs/muse"
+	copy_single "$HOME/.config/muse/settings.json" "$SCRIPT_DIR/configs/muse/settings.json"
+	log_success "Muse Code configs generated"
+}
+
 generate_amp_configs() {
 	log_info "Generating Amp configs..."
 
@@ -1181,6 +1194,9 @@ main() {
 	echo
 
 	generate_fx_configs
+	echo
+
+	generate_muse_configs
 	echo
 
 	generate_amp_configs

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -321,6 +321,19 @@ install_fx() {
 	run_installer "fx" "_run_fx_install" "command -v fx" "fx --version"
 }
 
+install_muse() {
+	if [ "$IS_WINDOWS" = true ]; then
+		log_warning "Muse Code supports macOS and Linux only."
+		log_info "Install Muse Code in a supported environment: https://dev.meta.ai/docs/muse-code"
+		return 0
+	fi
+
+	_run_muse_install() {
+		execute_installer "https://dev.meta.ai/install.sh" "" "Muse Code"
+	}
+	run_installer "Muse Code" "_run_muse_install" "command -v muse" "muse --version"
+}
+
 install_rtk() {
 	if [ "${IS_WINDOWS:-false}" = true ]; then
 		log_warning "RTK automatic installation is unavailable on native Windows"

--- a/lib/install.sh
+++ b/lib/install.sh
@@ -16,7 +16,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/install-deps.sh"
 ensure_dir_on_path() {
 	local dir="${1:-}"
 	[ -n "$dir" ] || return 0
-	if case ":$PATH:" in *":$dir:"*) false ;; *) true ;; esac; then
+	if case ":$PATH:" in *":$dir:"*) false ;; *) true ;; esac then
 		export PATH="$dir:$PATH"
 	fi
 }
@@ -96,6 +96,9 @@ resolve_installer_checksum() {
 		;;
 	rtk)
 		checksum_url="${RTK_INSTALL_SHA256_URL:-}"
+		;;
+	muse)
+		checksum_url="${MUSE_INSTALL_SHA256_URL:-}"
 		;;
 	esac
 
@@ -328,10 +331,16 @@ install_muse() {
 		return 0
 	fi
 
+	ensure_dir_on_path "$HOME/.local/bin"
+
 	_run_muse_install() {
-		execute_installer "https://dev.meta.ai/install.sh" "" "Muse Code"
+		ensure_dir_on_path "$HOME/.local/bin"
+		local muse_checksum
+		muse_checksum=$(resolve_installer_checksum "muse")
+		execute_installer "https://dev.meta.ai/install.sh" "$muse_checksum" "Muse Code"
+		ensure_dir_on_path "$HOME/.local/bin"
 	}
-	run_installer "Muse Code" "_run_muse_install" "command -v muse" "muse --version"
+	run_installer "Muse Code" "_run_muse_install" "command -v muse || test -x \"\$HOME/.local/bin/muse\"" "if [ -x \"\$HOME/.local/bin/muse\" ]; then \"\$HOME/.local/bin/muse\" --version; else muse --version; fi"
 }
 
 install_rtk() {
@@ -394,8 +403,7 @@ install_opencode2() {
 				npm) execute "npm install -g @opencode-ai/cli@next" ;;
 				pnpm) execute "pnpm add -g --allow-build=@opencode-ai/cli @opencode-ai/cli@next" ;;
 				yarn) execute "yarn global add @opencode-ai/cli@next" ;;
-				esac
-			then
+				esac then
 				log_error "OpenCode 2 installation failed"
 				return 1
 			fi
@@ -718,7 +726,7 @@ install_deepseek_harness() {
 
 	local node_major node_minor
 	read -r node_major node_minor <<<"$(node -p 'process.versions.node.split(".").slice(0, 2).join(" ")' 2>/dev/null)"
-	if ! [[ "$node_major" =~ ^[0-9]+$ && "$node_minor" =~ ^[0-9]+$ ]] || \
+	if ! [[ "$node_major" =~ ^[0-9]+$ && "$node_minor" =~ ^[0-9]+$ ]] ||
 		! { [ "$node_major" -eq 22 ] && [ "$node_minor" -ge 19 ] || [ "$node_major" -ge 24 ]; }; then
 		log_error "DeepSeek Harness requires Node.js 22.19+ or 24+ (found: $(node --version 2>/dev/null || echo unknown))."
 		return 1

--- a/tests/pr_delta.bats
+++ b/tests/pr_delta.bats
@@ -14,11 +14,14 @@ README="$REPO_ROOT/README.md"
 	[ -f "$REPO_ROOT/configs/delta/settings.json" ]
 	require_jq
 	run jq -e '
-		.send_message_with_modifier == true and
-		.cursor_after_send == "next_user_message" and
-		.default_diff_base == "uncommitted" and
-		.diff_color_scheme == "blue_orange" and
-		.diff_signs == true
+		.version == 1 and
+		.portable.send_message_with_modifier == true and
+		.portable.cursor_after_send == "agent_response" and
+		.portable.default_diff_base == "branch" and
+		.portable.diff_color_scheme == "green_red" and
+		.portable.diff_signs == false and
+		.native.os_notifications == true and
+		.native.prevent_system_sleep == true
 	' "$REPO_ROOT/configs/delta/settings.json"
 	[ "$status" -eq 0 ]
 }

--- a/tests/pr_muse.bats
+++ b/tests/pr_muse.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# Tests for Meta Muse Code integration
+
+load helpers
+
+CONFIG_DIR="$REPO_ROOT/configs/muse"
+
+@test "Muse settings use schema version 1 and valid MCP entries" {
+	run jq -e '
+		.schema_version == 1 and
+		(.mcp_servers | type == "object" and length > 0) and
+		([.mcp_servers[] |
+			.transport == "stdio" and
+			(.command | type == "string" and length > 0) and
+			(.args | type == "array") and
+			.enabled == true and
+			.mode == "optional"
+		] | all)
+	' "$CONFIG_DIR/settings.json"
+	[ "$status" -eq 0 ]
+}
+
+@test "Muse uses the official installer and muse binary" {
+	run grep -F 'execute_installer "https://dev.meta.ai/install.sh"' "$REPO_ROOT/lib/install.sh"
+	[ "$status" -eq 0 ]
+	run grep -F '"muse:install_muse"' "$REPO_ROOT/cli.sh"
+	[ "$status" -eq 0 ]
+}
+
+@test "Muse config install copies managed settings" {
+	local test_home="$BATS_TEST_TMPDIR/muse-copy-home"
+	mkdir -p "$test_home/.config/muse"
+
+	run env HOME="$test_home" REPO_ROOT="$REPO_ROOT" bash -c '
+		export DRY_RUN=false YES_TO_ALL=false VERBOSE=false
+		source "$REPO_ROOT/cli.sh"
+		copy_muse_configs
+	'
+
+	[ "$status" -eq 0 ]
+	cmp "$CONFIG_DIR/settings.json" "$test_home/.config/muse/settings.json"
+}
+
+@test "Muse backup and export include managed settings only" {
+	local test_home="$BATS_TEST_TMPDIR/muse-sync-home"
+	local output_repo="$BATS_TEST_TMPDIR/muse-output-repo"
+	mkdir -p "$test_home/.config/muse/sessions" "$output_repo"
+	cp "$CONFIG_DIR/settings.json" "$test_home/.config/muse/settings.json"
+	touch "$test_home/.config/muse/credentials.json" "$test_home/.config/muse/sessions/private.json"
+
+	run env HOME="$test_home" REPO_ROOT="$REPO_ROOT" OUTPUT_REPO="$output_repo" bash -c '
+		export DRY_RUN=false YES_TO_ALL=false VERBOSE=false
+		source "$REPO_ROOT/cli.sh"
+		BACKUP=true
+		PROMPT_BACKUP=false
+		BACKUP_DIR="$HOME/backup"
+		backup_configs >/dev/null
+
+		source "$REPO_ROOT/generate.sh"
+		SCRIPT_DIR="$OUTPUT_REPO"
+		generate_muse_configs >/dev/null
+	'
+
+	[ "$status" -eq 0 ]
+	cmp "$CONFIG_DIR/settings.json" "$test_home/backup/muse/settings.json"
+	cmp "$CONFIG_DIR/settings.json" "$output_repo/configs/muse/settings.json"
+	[ ! -e "$test_home/backup/muse/credentials.json" ]
+	[ ! -e "$output_repo/configs/muse/credentials.json" ]
+	[ ! -e "$output_repo/configs/muse/sessions" ]
+}
+
+@test "README documents Muse Code and the SDK as separate installs" {
+	run grep -F 'curl -fsSL https://dev.meta.ai/install.sh | sh' "$REPO_ROOT/README.md"
+	[ "$status" -eq 0 ]
+	run grep -F 'npm install @muse-code/sdk' "$REPO_ROOT/README.md"
+	[ "$status" -eq 0 ]
+	run grep -F 'Node.js 20+' "$REPO_ROOT/README.md"
+	[ "$status" -eq 0 ]
+}
+
+@test "Muse support has a changeset" {
+	[ -f "$REPO_ROOT/.changeset/add-muse-code-support.md" ]
+}

--- a/tests/pr_muse.bats
+++ b/tests/pr_muse.bats
@@ -8,12 +8,11 @@ CONFIG_DIR="$REPO_ROOT/configs/muse"
 @test "Muse settings use schema version 1 and valid MCP entries" {
 	run jq -e '
 		.schema_version == 1 and
-		(.mcp_servers | type == "object" and length > 0) and
-		([.mcp_servers[] |
+		(.mcpServers | type == "object" and length > 0) and
+		([.mcpServers[] |
 			.transport == "stdio" and
 			(.command | type == "string" and length > 0) and
-			(.args | type == "array") and
-			.enabled == true and
+			((.args // []) | type == "array") and
 			.mode == "optional"
 		] | all)
 	' "$CONFIG_DIR/settings.json"


### PR DESCRIPTION
## Summary

- add Meta Muse Code to the installer, active-tool allowlist, config validation, backup, and bidirectional sync flows
- add native `~/.config/muse/settings.json` MCP configuration using Muse schema version 1
- document the out-of-beta CLI features (session messaging, workflows, and rewind) and the developer-preview `@muse-code/sdk` as a separate per-project dependency
- add functional Muse integration coverage and a minor changeset

## Validation

- `./cli.sh --dry-run </dev/null`
- `bash -n cli.sh generate.sh install.sh scripts/*.sh lib/*.sh`
- `./scripts/sync-token-efficiency.sh --check`
- `npx --yes bats tests/` (552 tests passed)
- `npx --yes bats tests/pr_muse.bats` (6 tests passed)
- `pre-commit run --files README.md cli.sh generate.sh lib/install.sh configs/muse/settings.json tests/pr_muse.bats .changeset/add-muse-code-support.md`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Meta Muse Code as a coding agent.
  * Added official Muse Code installation for macOS and Linux.
  * Added managed MCP configuration, backup, export, and synchronization.
  * Added Muse Code to the all-tools installation workflow.
  * Expanded Delta configuration with additional preferences and appearance options.
  * Updated Delta settings to use the latest portable and native configuration structure.
* **Documentation**
  * Documented Muse Code setup, CLI features, MCP integration, and developer-preview SDK.
* **Tests**
  * Added coverage for Muse Code installation, configuration, documentation, and release metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->