### PR TITLE
docs: add Lane to companion tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -3610,6 +3610,10 @@ RTK is installed automatically on macOS, Linux, and WSL. Native Windows users sh
 
 [**Try**](https://github.com/tobi/try) - Fresh directories for every vibe. ([Interactive Demo](https://asciinema.org/a/ve8AXBaPhkKz40YbqPTlVjqgs))
 
+### Lane
+
+[**Lane**](https://github.com/lukeed/lane) - Rust CLI for copy-on-write Git worktrees with warm ignored caches and code-anchored context that persists across branches and coding-agent sessions.
+
 ### Claude Squad
 
 [**Claude Squad**](https://github.com/smtg-ai/claude-squad) - Manage multiple AI agents in separate workspaces with isolated git worktrees.


### PR DESCRIPTION
## What

Add [Lane](https://github.com/lukeed/lane) to the README's curated Companion Tools catalog.

## Why

Lane complements the existing worktree-focused tools with copy-on-write worktrees, warm ignored caches, and durable code-anchored context for parallel and agent-assisted development.

## How

Placed a concise, repository-verified description beside Try and Claude Squad without adding Lane to the agent-skills installer, since Lane is a standalone Rust CLI rather than a skills collection.

## Validation

- `git diff --check`
- EOF and trailing-whitespace validation for `README.md`
- `npx --yes oxfmt@0.51.0 --check` on the added Lane block
- Verified `lukeed/lane` is active and the linked repository resolves through the GitHub API

> Note: the repository's documented `pre-commit` executable is unavailable in the orb. Full-file `oxfmt --check README.md` also reports unrelated pre-existing formatting drift elsewhere in the README; the added block passes the pinned formatter independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Lane to the Companion Tools section.
  * Described its Rust CLI capabilities for copy-on-write Git worktrees, warm ignored caches, and persistent code-anchored context across branches and coding-agent sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->