### PR TITLE
feat(skills): recommend Archify

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,6 +879,7 @@ Official and community-maintained skill collections for specific frameworks:
 | **Improve Code Architect** | [shadcn/improve](https://github.com/shadcn/improve)                                                           | Frontier model plans, cheap model executes — audit any codebase and produce implementation plans for cheaper models to run.                                                                                                    |
 | **Engram**                 | [Gentleman-Programming/engram](https://github.com/Gentleman-Programming/engram)                               | Persistent agent memory via single Go binary — SQLite + FTS5, 20 MCP tools, zero dependencies, TUI, and git-based cross-machine sync.                                                                                          |
 | **mac-OCR**                | [privatenumber/mac-ocr](https://github.com/privatenumber/mac-ocr)                                             | macOS CLI for OCR and searchable PDFs using Apple's Vision framework                                                                                                                                                           |
+| **Archify**                | [tt-a1i/archify](https://github.com/tt-a1i/archify)                                                           | Turn a codebase or system description into a polished, interactive system map directly in chat. Supports architecture, workflow, sequence, data-flow, and lifecycle diagrams.                                                  |
 
 **Installation:**
 
@@ -903,6 +904,7 @@ npx skills add mvanhorn/last30days-skill --global --agent claude-code
 npx skills add shadcn/improve --global --agent claude-code
 npx skills add Gentleman-Programming/engram --skill engram-memory --global --agent claude-code
 npx skills add ctxrs/ctx --global --agent claude-code
+npx skills add tt-a1i/archify --skill archify --global --agent claude-code
 ```
 
 ### Configuration Files

--- a/configs/recommend-skills.json
+++ b/configs/recommend-skills.json
@@ -80,6 +80,11 @@
 		{
 			"repo": "ctxrs/ctx",
 			"description": "Install the ctx agent-history search skill — gives agents the ability to search past coding sessions before editing"
+		},
+		{
+			"repo": "tt-a1i/archify",
+			"skill": "archify",
+			"description": "Turn a codebase or system description into a polished, interactive system map directly in chat"
 		}
 	]
 }

--- a/tests/recommend_skills.bats
+++ b/tests/recommend_skills.bats
@@ -441,3 +441,29 @@ README_FILE="$REPO_ROOT/README.md"
     [ "$status" -eq 0 ]
     [ "$output" = "true" ]
 }
+
+@test "recommend-skills.json contains tt-a1i/archify skill entry" {
+    if ! command -v jq &>/dev/null; then
+        skip "jq not installed"
+    fi
+    run jq -e '[.recommended_skills[] | select(.repo == "tt-a1i/archify" and .skill == "archify")] | length == 1' "$RECOMMEND_SKILLS_JSON"
+    [ "$status" -eq 0 ]
+    [ "$output" = "true" ]
+}
+
+@test "archify entry describes interactive system maps" {
+    if ! command -v jq &>/dev/null; then
+        skip "jq not installed"
+    fi
+    run jq -r '[.recommended_skills[] | select(.skill == "archify")][0].description' "$RECOMMEND_SKILLS_JSON"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"interactive system map"* ]]
+}
+
+@test "README.md documents Archify and its install command" {
+    run grep -F 'https://github.com/tt-a1i/archify' "$README_FILE"
+    [ "$status" -eq 0 ]
+
+    run grep -F 'npx skills add tt-a1i/archify --skill archify --global --agent claude-code' "$README_FILE"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- add `tt-a1i/archify` to the recommended community skills registry
- document Archify and its Claude Code install command
- add regression coverage for the registry entry and README documentation

## Validation

- `npx -y skills add tt-a1i/archify --list` (resolved the `archify` skill)
- `bats tests/recommend_skills.bats` (55 passed)
- `bats tests/pr_*.bats tests/generate.bats tests/sh_reexec.bats` (439 passed)
- `bash -n cli.sh generate.sh install.sh scripts/*.sh`
- `./scripts/sync-token-efficiency.sh --check`
- `bunx --bun biome check README.md configs/recommend-skills.json tests/recommend_skills.bats`

## Note

`bats tests/` ran 549 tests with one unrelated environment-dependent failure: `validate_yaml fails on invalid yaml with spaces in path` expects a YAML parser, but this orb has Python without PyYAML and no Ruby/yq fallback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Archify to the recommended community skills list.
  * Documented Archify’s interactive system-mapping capabilities and installation command.

* **Tests**
  * Added coverage verifying the Archify recommendation, description, repository link, and installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->